### PR TITLE
ci: use PAT for release-please to trigger downstream workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,3 +16,4 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           release-type: node
+          token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `token: ${{ secrets.RELEASE_TOKEN }}` to the release-please action so tags it creates trigger `build-image.yml`
- GitHub suppresses `on: push` triggers for events created by `GITHUB_TOKEN` (to prevent infinite loops). Using a PAT attributes the tag to a real user, allowing downstream workflows to fire.

## Manual steps required

1. Create a **fine-grained PAT** at https://github.com/settings/personal-access-tokens scoped to this repo with `contents: write` and `pull-requests: write`
2. Add it as a repo secret named `RELEASE_TOKEN` (Settings → Secrets and variables → Actions)