### PR TITLE
feat: enable live action execution and add has_file fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ Roombarr is configured through a single YAML file. The config file is resolved i
 1. Path set by the `CONFIG_PATH` environment variable
 2. `/config/roombarr.yml`
 
+### `dry_run`
+
+Controls whether Roombarr executes actions against Radarr/Sonarr or just logs what it would do. Defaults to `true`.
+
+```yaml
+dry_run: false  # Set to false to enable live execution
+```
+
+When `dry_run: true` (the default), evaluations run normally and log results, but no media is deleted or unmonitored. When `dry_run: false`, Roombarr will call Radarr/Sonarr APIs to perform the resolved actions after each evaluation.
+
 ### `services`
 
 Connections to your *arr stack. At least one of `sonarr` or `radarr` must be configured.
@@ -136,7 +146,7 @@ performance:
 
 ### `audit`
 
-Destructive actions are logged to daily-rotated JSONL files at `/config/logs/`. In v1, all entries are tagged `dry_run: true`.
+Destructive actions are logged to daily-rotated JSONL files. Each entry is tagged with `dry_run: true` or `dry_run: false` reflecting the mode at evaluation time.
 
 ```yaml
 audit:

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Available on rules with `target: radarr`.
 | `radarr.digital_release` | date | Digital release date | Can be null. Null dates always match `older_than`, never match `newer_than`. |
 | `radarr.physical_release` | date | Physical release date | Can be null. Same null behavior as above. |
 | `radarr.size_on_disk` | number | File size in bytes | |
+| `radarr.has_file` | boolean | Whether a file exists on disk | |
 | `radarr.monitored` | boolean | Whether the movie is monitored | |
 | `radarr.on_import_list` | boolean | Whether the movie is on any import list | |
 | `radarr.status` | string | Release status (e.g., `released`, `announced`) | |
@@ -402,6 +403,7 @@ Available on rules with `target: sonarr`. Sonarr rules evaluate per-season, so s
 | `sonarr.season.episode_count` | number | Total episodes in the season | Season-level |
 | `sonarr.season.episode_file_count` | number | Episodes with files downloaded | Season-level |
 | `sonarr.season.size_on_disk` | number | Season file size in bytes | Season-level |
+| `sonarr.season.has_file` | boolean | Whether the season has any episode files | Derived from episode_file_count > 0. Season-level |
 
 ### Jellyfin Fields
 

--- a/docs/plans/2026-03-04-feat-enable-live-action-execution-plan.md
+++ b/docs/plans/2026-03-04-feat-enable-live-action-execution-plan.md
@@ -1,0 +1,448 @@
+---
+title: "feat: Enable live action execution (delete/unmonitor)"
+type: feat
+status: completed
+date: 2026-03-04
+origin: docs/brainstorms/2026-02-13-rule-based-media-cleanup-brainstorm.md
+---
+
+# feat: Enable live action execution (delete/unmonitor)
+
+## Overview
+
+Roombarr v1 is permanently hardcoded to dry-run mode — it evaluates rules, logs what *would* happen, but never calls Radarr/Sonarr mutation APIs. This feature adds the missing "execute" step to the evaluation pipeline and exposes a `dry_run` config option (default: `true`) so users can preview destructive actions before committing.
+
+The brainstorm established this as an intentional phased rollout: *"Live execution will be added once the rule engine is trusted"* (see brainstorm: `docs/brainstorms/2026-02-13-rule-based-media-cleanup-brainstorm.md`). The rule engine has been stable — time to let it do damage.
+
+## Problem Statement / Motivation
+
+Without live execution, Roombarr is an expensive logger. Users can see what *would* happen but must manually delete/unmonitor items in Radarr/Sonarr. This defeats the purpose of an automated cleanup engine. The entire value proposition depends on this feature shipping.
+
+## Proposed Solution
+
+Add a top-level `dry_run` config option and an `ActionExecutorService` that sits between evaluation and response in the pipeline. When `dry_run: false`, the executor calls Radarr/Sonarr APIs to perform the resolved actions. When `dry_run: true` (default), behavior is identical to v1.
+
+**Updated pipeline:** hydrate → snapshot → enrich → evaluate → **execute** → respond
+
+## Technical Considerations
+
+### 1. Internal ID Resolution (Critical Prerequisite)
+
+Every Radarr/Sonarr mutation API requires internal IDs (`RadarrMovie.id`, `SonarrSeries.id`), but the unified models currently only carry external IDs (`tmdb_id`, `tvdb_id`). The mappers in `radarr.service.ts` and `sonarr.service.ts` discard these during `.map()`.
+
+**Approach:** Add internal IDs directly to the unified models:
+- `UnifiedMovie` gains `radarr_id: number`
+- `UnifiedSeason` gains `sonarr_series_id: number`
+
+This is the lowest-friction path. The alternative (reverse-lookup map) adds complexity for no real benefit — the internal IDs aren't sensitive and belong on the model.
+
+**Files affected:**
+- `src/shared/types.ts` — add `radarr_id` to `UnifiedMovie`, `sonarr_series_id` to `UnifiedSeason`
+- `src/radarr/radarr.mapper.ts` — preserve `id` during mapping
+- `src/sonarr/sonarr.mapper.ts` — preserve `id` during mapping
+- `src/radarr/radarr.service.ts` — pass `id` through
+- `src/sonarr/sonarr.service.ts` — pass `id` through
+- `src/database/schema.ts` — if snapshots need the internal IDs (evaluate during implementation)
+- Test factories (`makeMovie()`, `makeSeason()`) — add default internal IDs
+
+### 2. Sonarr Episode File Fetching
+
+Deleting a season's files requires episode file IDs, which the current `SonarrClient` doesn't fetch. Sonarr exposes `GET /api/v3/episodefile?seriesId={id}` returning all episode files for a series.
+
+**Approach:** Fetch lazily during execution (not during hydration). Only seasons with `resolved_action: 'delete'` need episode file IDs. This avoids adding latency to dry-run evaluations.
+
+**Files affected:**
+- `src/sonarr/sonarr.client.ts` — add `fetchEpisodeFiles(seriesId: number): Promise<SonarrEpisodeFile[]>`
+- `src/sonarr/sonarr.client.ts` — add `deleteEpisodeFile(episodeFileId: number): Promise<void>`
+- `src/sonarr/sonarr.types.ts` — add `SonarrEpisodeFile` interface
+
+### 3. Radarr/Sonarr Mutation API Endpoints
+
+| Action | Service | HTTP Method | Endpoint | Notes |
+|--------|---------|-------------|----------|-------|
+| Delete movie | Radarr | `DELETE` | `/api/v3/movie/{id}?deleteFiles=true` | Irreversible. Removes movie + files from disk. |
+| Unmonitor movie | Radarr | `PUT` | `/api/v3/movie/{id}` | Must send full movie body with `monitored: false`. Reversible. |
+| Delete season files | Sonarr | `DELETE` | `/api/v3/episodefile/{id}` | Per episode file. Irreversible. |
+| Unmonitor season | Sonarr | `PUT` | `/api/v3/series/{id}` | Must send full series body with season's `monitored: false`. Reversible. |
+
+**Unmonitor PUT body strategy:** Re-fetch the resource by internal ID at execution time, flip the `monitored` field, PUT the full object back. This adds one extra GET per unmonitor action but guarantees no metadata corruption from partial bodies.
+
+**Files affected:**
+- `src/radarr/radarr.client.ts` — add `deleteMovie(id, deleteFiles)`, `fetchMovie(id)`, `updateMovie(id, body)`
+- `src/sonarr/sonarr.client.ts` — add `fetchSeries(id)`, `updateSeries(id, body)`, `fetchEpisodeFiles(seriesId)`, `deleteEpisodeFile(id)`
+
+### 4. Config Schema
+
+Add `dry_run` as a top-level boolean, defaulting to `true`.
+
+```yaml
+# roombarr.yml
+dry_run: true  # Set to false to enable live execution
+
+services:
+  # ...
+schedule: "0 3 * * *"
+rules:
+  # ...
+```
+
+**Files affected:**
+- `src/config/config.schema.ts` — add `dry_run` to `configSchema` (`.default(true)`) and `RoombarrConfig` interface
+- `src/config/config.service.ts` — no changes needed (config is already fully typed)
+
+### 5. ActionExecutorService Design
+
+A new NestJS injectable service in the `evaluation` module (or a new `execution` module — evaluate during implementation).
+
+```
+ActionExecutorService
+├── execute(results: EvaluationItemResult[], dryRun: boolean): Promise<ExecutionResult[]>
+│   ├── if dryRun → return results unchanged (no-op)
+│   ├── filter to items with resolved_action !== null and resolved_action !== 'keep'
+│   ├── for each item (sequential, concurrency=1 for safety in v1):
+│   │   ├── resolve internal ID from result
+│   │   ├── call appropriate mutation API
+│   │   ├── record success/failure per item
+│   │   └── write audit entry AFTER execution attempt
+│   └── return results with execution status
+├── deleteRadarrMovie(radarrId: number): Promise<void>
+├── unmonitorRadarrMovie(radarrId: number): Promise<void>
+├── deleteSonarrSeasonFiles(seriesId: number, seasonNumber: number): Promise<void>
+└── unmonitorSonarrSeason(seriesId: number, seasonNumber: number): Promise<void>
+```
+
+**Key design decisions:**
+- **Sequential execution** (no parallelism) for v1. Mutations are dangerous; sequential makes debugging and audit trails predictable.
+- **Continue on failure.** If item 4 of 10 fails, items 5-10 still execute. Per-item status tracking reports what happened.
+- **404 = success with warning.** If Radarr returns 404 on a delete, the desired state is achieved — someone else already removed it.
+- **Audit after execution.** Move audit logging from `RulesService.evaluate()` to after execution completes. In dry-run mode, audit still logs during evaluation (preserving v1 behavior). In live mode, audit logs after each action attempt with the execution outcome.
+
+**Files to create:**
+- `src/execution/action-executor.service.ts`
+- `src/execution/action-executor.service.test.ts`
+- `src/execution/execution.module.ts`
+- `src/execution/execution.types.ts`
+
+### 6. Type System Changes
+
+**`EvaluationItemResult.dry_run`**: Change from literal `true` to `boolean`. Add execution tracking fields.
+
+```typescript
+export interface EvaluationItemResult {
+  title: string;
+  type: 'movie' | 'season';
+  external_id: number;
+  matched_rules: string[];
+  resolved_action: Action | null;
+  dry_run: boolean;
+  /** Internal ID needed for API calls. Radarr movie ID or Sonarr series ID. */
+  internal_id: number;
+  /** Present only when dry_run is false and an action was attempted. */
+  execution_status?: 'success' | 'failed' | 'skipped';
+  /** Error message if execution_status is 'failed'. */
+  execution_error?: string;
+}
+```
+
+**`EvaluationSummary`**: Add execution counts.
+
+```typescript
+export interface EvaluationSummary {
+  items_evaluated: number;
+  items_matched: number;
+  actions: Record<Action, number>;
+  rules_skipped_missing_data: number;
+  /** Present only when dry_run is false. */
+  actions_executed?: Record<Action, number>;
+  actions_failed?: number;
+}
+```
+
+**Ripple locations:**
+- `src/rules/types.ts:14` — `dry_run: true` → `dry_run: boolean`
+- `src/rules/rules.service.ts:85` — `dryRun: true` → `dryRun: config.dry_run`
+- `src/rules/rules.service.ts:97` — `dry_run: true` → `dry_run: config.dry_run`
+- `src/evaluation/evaluation.controller.ts:69` — `dry_run: true` → `dry_run: config.dry_run`
+- `src/evaluation/evaluation.service.ts` — wire executor into `executeEvaluation()`
+- `src/rules/rules.service.test.ts` — update assertions from `dry_run: true` to parameterized
+
+### 7. Startup Banner
+
+When `dry_run: false`, emit a prominent startup log:
+
+```
+⚠️  LIVE MODE ENABLED — actions will be executed against Radarr/Sonarr
+```
+
+When `dry_run: true` (default):
+
+```
+ℹ️  DRY RUN MODE — no actions will be executed
+```
+
+This goes in `main.ts` or `EvaluationModule.onModuleInit()`.
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [x]New top-level `dry_run` config option (boolean, default: `true`)
+- [x]`dry_run: true` — behavior identical to v1 (evaluate + log, no mutations)
+- [x]`dry_run: false` — execute resolved actions against Radarr/Sonarr APIs after evaluation
+- [x]**Radarr delete:** calls `DELETE /api/v3/movie/{id}?deleteFiles=true`
+- [x]**Radarr unmonitor:** re-fetches movie, sets `monitored: false`, PUTs full body
+- [x]**Sonarr season delete:** fetches episode files for season, deletes each via `DELETE /api/v3/episodefile/{id}`
+- [x]**Sonarr season unmonitor:** re-fetches series, sets season `monitored: false`, PUTs full body
+- [x]`keep` actions are never executed (they are protective, no mutation needed)
+- [x]Per-item execution status tracked (`success`, `failed`, `skipped`)
+- [x]Partial failures do not abort remaining items — continue and report
+- [x]404 from Radarr/Sonarr during delete treated as success (desired state achieved)
+- [x]Audit log entries include execution outcome when in live mode
+- [x]Startup banner indicates whether system is in dry-run or live mode
+- [x]Evaluation API response includes `dry_run: boolean` reflecting actual mode
+- [x]Evaluation summary includes `actions_executed` and `actions_failed` counts in live mode
+- [x]Internal IDs (`radarr_id`, `sonarr_series_id`) available on unified models
+
+### Testing Requirements
+
+- [x]Unit tests for `ActionExecutorService` — mock Radarr/Sonarr clients, verify correct API calls per action type
+- [x]Unit tests for dry-run pass-through (executor is a no-op)
+- [x]Unit tests for partial failure handling (continue after error)
+- [x]Unit tests for 404-as-success behavior
+- [x]Unit tests for unmonitor flow (re-fetch → modify → PUT)
+- [x]Unit tests for Sonarr season delete (fetch episode files → filter by season → delete each)
+- [x]Updated tests in `rules.service.test.ts` for parameterized `dry_run`
+- [x]Config schema validation tests for `dry_run` field
+
+## Success Metrics
+
+- Evaluation runs with `dry_run: false` successfully delete/unmonitor items in Radarr/Sonarr
+- Audit logs accurately reflect what was executed vs. what was decided
+- Zero unintended mutations when `dry_run: true` (regression safety)
+- All existing tests continue to pass with updated types
+
+## Dependencies & Risks
+
+### Dependencies
+- Radarr API v3 must support `DELETE /api/v3/movie/{id}?deleteFiles=true`
+- Sonarr API v3 must support `GET /api/v3/episodefile?seriesId={id}` and `DELETE /api/v3/episodefile/{id}`
+- Both APIs must accept `PUT` with full resource body for unmonitor operations
+
+### Risks
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Misconfigured rule deletes entire library | Medium | Critical | `dry_run: true` default. Users must explicitly opt in. |
+| Radarr/Sonarr API changes in future versions | Low | Medium | Client methods are thin wrappers; easy to update. |
+| Partial execution leaves inconsistent state | Medium | Medium | Per-item tracking + continue-on-failure + audit logging. |
+| Unmonitor PUT corrupts metadata | Low | High | Re-fetch full resource before PUT; never send partial bodies. |
+
+### Future Considerations (Not in Scope)
+- **Blast-radius limit** (`max_actions_per_run`) — prevent catastrophic misconfiguration
+- **Per-rule `dry_run` override** — some rules live, others preview-only
+- **Execution concurrency** — parallel mutations for large libraries
+- **Confirmation period** — run dry once, execute on next matching run
+- **Notification integrations** — Discord/webhook alerts on live execution
+
+## MVP
+
+### `src/config/config.schema.ts` — Add dry_run to schema
+
+```typescript
+export const configSchema = z.object({
+  dry_run: z.boolean().default(true),
+  services: servicesSchema,
+  schedule: z.string().min(1),
+  performance: performanceSchema,
+  audit: auditSchema,
+  rules: z.array(ruleSchema).min(1),
+});
+```
+
+### `src/shared/types.ts` — Add internal IDs to unified models
+
+```typescript
+export interface UnifiedMovie {
+  type: 'movie';
+  radarr_id: number;  // Internal Radarr movie ID for API mutations
+  tmdb_id: number;
+  imdb_id: string | null;
+  title: string;
+  year: number;
+  radarr: RadarrData;
+  jellyfin: JellyfinData | null;
+  jellyseerr: JellyseerrData | null;
+  state: StateData | null;
+}
+
+export interface UnifiedSeason {
+  type: 'season';
+  sonarr_series_id: number;  // Internal Sonarr series ID for API mutations
+  tvdb_id: number;
+  title: string;
+  year: number;
+  sonarr: SonarrData;
+  jellyfin: JellyfinData | null;
+  jellyseerr: JellyseerrData | null;
+  state: StateData | null;
+}
+```
+
+### `src/radarr/radarr.client.ts` — Add mutation methods
+
+```typescript
+async deleteMovie(movieId: number, deleteFiles = true): Promise<void> {
+  this.logger.debug(`Deleting movie ${movieId} (deleteFiles: ${deleteFiles})`);
+  await firstValueFrom(
+    this.http.delete(`/api/v3/movie/${movieId}`, {
+      params: { deleteFiles },
+    }),
+  );
+}
+
+async fetchMovie(movieId: number): Promise<RadarrMovie> {
+  const { data } = await firstValueFrom(
+    this.http.get<RadarrMovie>(`/api/v3/movie/${movieId}`),
+  );
+  return data;
+}
+
+async updateMovie(movieId: number, body: RadarrMovie): Promise<void> {
+  await firstValueFrom(
+    this.http.put(`/api/v3/movie/${movieId}`, body),
+  );
+}
+```
+
+### `src/sonarr/sonarr.client.ts` — Add mutation methods
+
+```typescript
+async fetchEpisodeFiles(seriesId: number): Promise<SonarrEpisodeFile[]> {
+  const { data } = await firstValueFrom(
+    this.http.get<SonarrEpisodeFile[]>('/api/v3/episodefile', {
+      params: { seriesId },
+    }),
+  );
+  return data;
+}
+
+async deleteEpisodeFile(episodeFileId: number): Promise<void> {
+  await firstValueFrom(
+    this.http.delete(`/api/v3/episodefile/${episodeFileId}`),
+  );
+}
+
+async fetchSeriesById(seriesId: number): Promise<SonarrSeries> {
+  const { data } = await firstValueFrom(
+    this.http.get<SonarrSeries>(`/api/v3/series/${seriesId}`),
+  );
+  return data;
+}
+
+async updateSeries(seriesId: number, body: SonarrSeries): Promise<void> {
+  await firstValueFrom(
+    this.http.put(`/api/v3/series/${seriesId}`, body),
+  );
+}
+```
+
+### `src/execution/action-executor.service.ts` — Core executor
+
+```typescript
+@Injectable()
+export class ActionExecutorService {
+  private readonly logger = new Logger(ActionExecutorService.name);
+
+  constructor(
+    private readonly radarrClient: RadarrClient,
+    private readonly sonarrClient: SonarrClient,
+    private readonly auditService: AuditService,
+  ) {}
+
+  /**
+   * Execute resolved actions against Radarr/Sonarr.
+   * In dry-run mode, this is a no-op — results pass through unchanged.
+   * In live mode, each actionable item is executed sequentially.
+   */
+  async execute(
+    results: EvaluationItemResult[],
+    items: UnifiedMedia[],
+    dryRun: boolean,
+    evaluationId: string,
+    reasoningCache: Map<string, string>,
+  ): Promise<EvaluationItemResult[]> {
+    if (dryRun) return results;
+
+    const itemsByExternalId = new Map(
+      items.map(i => [i.type === 'movie' ? i.tmdb_id : i.tvdb_id, i]),
+    );
+
+    const executed: EvaluationItemResult[] = [];
+
+    for (const result of results) {
+      if (!result.resolved_action || result.resolved_action === 'keep') {
+        executed.push(result);
+        continue;
+      }
+
+      const item = itemsByExternalId.get(result.external_id);
+      if (!item) {
+        executed.push({
+          ...result,
+          execution_status: 'failed',
+          execution_error: 'Item not found in hydrated data',
+        });
+        continue;
+      }
+
+      try {
+        await this.executeAction(item, result.resolved_action);
+        executed.push({ ...result, execution_status: 'success' });
+      } catch (error) {
+        const is404 = /* check for 404 status */;
+        if (is404) {
+          this.logger.warn(`${result.resolved_action} ${result.title}: 404 — already removed`);
+          executed.push({ ...result, execution_status: 'success' });
+        } else {
+          executed.push({
+            ...result,
+            execution_status: 'failed',
+            execution_error: error instanceof Error ? error.message : 'Unknown error',
+          });
+        }
+      }
+    }
+
+    return executed;
+  }
+}
+```
+
+## Sources & References
+
+### Origin
+
+- **Brainstorm document:** [docs/brainstorms/2026-02-13-rule-based-media-cleanup-brainstorm.md](docs/brainstorms/2026-02-13-rule-based-media-cleanup-brainstorm.md) — Key decisions carried forward: dry-run as v1 default, actions are `delete`/`unmonitor`/`keep`, least-destructive-wins conflict resolution.
+
+### Internal References
+
+- Evaluation pipeline: `src/evaluation/evaluation.service.ts:117` (`executeEvaluation`)
+- Hardcoded dry-run: `src/rules/rules.service.ts:85` and `:97`
+- Literal type constraint: `src/rules/types.ts:14`
+- Controller hardcoded response: `src/evaluation/evaluation.controller.ts:69`
+- Audit service (already supports `dry_run: boolean`): `src/audit/audit.service.ts:53`
+- Radarr client (read-only): `src/radarr/radarr.client.ts`
+- Sonarr client (read-only): `src/sonarr/sonarr.client.ts`
+- Config schema: `src/config/config.schema.ts:134`
+- Unified model types: `src/shared/types.ts`
+
+### External References
+
+- Radarr API v3 docs: https://radarr.video/docs/api/
+- Sonarr API v3 docs: https://sonarr.tv/docs/api/
+- Audit logging plan: `docs/plans/2026-02-15-feat-audit-logging-destructive-actions-plan.md`
+- Persistence migration solution: `docs/solutions/database-issues/raw-sqlite-to-drizzle-orm-migration.md`
+
+### Related Work
+
+- Audit logging (completed): supports `dry_run: boolean` discriminator in entries
+- Drizzle persistence layer (completed): snapshot schema may need internal ID columns

--- a/docs/plans/2026-03-04-feat-enable-live-action-execution-plan.md
+++ b/docs/plans/2026-03-04-feat-enable-live-action-execution-plan.md
@@ -96,25 +96,28 @@ A new NestJS injectable service in the `evaluation` module (or a new `execution`
 
 ```
 ActionExecutorService
-├── execute(results: EvaluationItemResult[], dryRun: boolean): Promise<ExecutionResult[]>
-│   ├── if dryRun → return results unchanged (no-op)
-│   ├── filter to items with resolved_action !== null and resolved_action !== 'keep'
-│   ├── for each item (sequential, concurrency=1 for safety in v1):
-│   │   ├── resolve internal ID from result
-│   │   ├── call appropriate mutation API
+├── execute(results: EvaluationItemResult[], items: UnifiedMedia[], dryRun: boolean)
+│   │   → Promise<{ results: EvaluationItemResult[]; executionSummary?: ExecutionSummary }>
+│   ├── if dryRun → mark every result with execution_status: 'skipped' (no API calls)
+│   ├── build itemsByInternalId map from items using buildInternalId()
+│   ├── for each result (sequential, concurrency=1 for safety in v1):
+│   │   ├── skip non-actionable items (resolved_action null or 'keep') → execution_status: 'skipped'
+│   │   ├── look up hydrated item by internal_id (composite string, e.g. 'movie:42')
+│   │   ├── call executeAction(item, resolved_action)
 │   │   ├── record success/failure per item
-│   │   └── write audit entry AFTER execution attempt
-│   └── return results with execution status
-├── deleteRadarrMovie(radarrId: number): Promise<void>
-├── unmonitorRadarrMovie(radarrId: number): Promise<void>
-├── deleteSonarrSeasonFiles(seriesId: number, seasonNumber: number): Promise<void>
-└── unmonitorSonarrSeason(seriesId: number, seasonNumber: number): Promise<void>
+│   │   └── 404 responses are logged as warnings (item already removed externally)
+│   └── return results with execution status + executionSummary counts
+├── executeAction(item: UnifiedMedia, action: Action): Promise<void>
+├── deleteMovie(movie: UnifiedMovie): Promise<void>
+├── unmonitorMovie(movie: UnifiedMovie): Promise<void>
+├── deleteSeasonFiles(season: UnifiedSeason): Promise<void>
+└── unmonitorSeason(season: UnifiedSeason): Promise<void>
 ```
 
 **Key design decisions:**
 - **Sequential execution** (no parallelism) for v1. Mutations are dangerous; sequential makes debugging and audit trails predictable.
 - **Continue on failure.** If item 4 of 10 fails, items 5-10 still execute. Per-item status tracking reports what happened.
-- **404 = success with warning.** If Radarr returns 404 on a delete, the desired state is achieved — someone else already removed it.
+- **404 = warning only.** If Radarr/Sonarr returns 404, it is logged as a warning (item already removed externally) but not counted as a successful execution. Per-file 404s during season file deletion are handled individually — the remaining files still execute.
 - **Audit after execution.** Move audit logging from `RulesService.evaluate()` to after execution completes. In dry-run mode, audit still logs during evaluation (preserving v1 behavior). In live mode, audit logs after each action attempt with the execution outcome.
 
 **Files to create:**
@@ -135,9 +138,9 @@ export interface EvaluationItemResult {
   matched_rules: string[];
   resolved_action: Action | null;
   dry_run: boolean;
-  /** Internal ID needed for API calls. Radarr movie ID or Sonarr series ID. */
-  internal_id: number;
-  /** Present only when dry_run is false and an action was attempted. */
+  /** Composite key unique per item (e.g. "movie:42", "season:10:1"). */
+  internal_id: string;
+  /** Set during execution. Present when dry_run is true ('skipped') or when an action was attempted in live mode. */
   execution_status?: 'success' | 'failed' | 'skipped';
   /** Error message if execution_status is 'failed'. */
   execution_error?: string;
@@ -196,7 +199,7 @@ This goes in `main.ts` or `EvaluationModule.onModuleInit()`.
 - [x]`keep` actions are never executed (they are protective, no mutation needed)
 - [x]Per-item execution status tracked (`success`, `failed`, `skipped`)
 - [x]Partial failures do not abort remaining items — continue and report
-- [x]404 from Radarr/Sonarr during delete treated as success (desired state achieved)
+- [x]404 from Radarr/Sonarr during delete logged as warning (item already removed); not counted as success or failure
 - [x]Audit log entries include execution outcome when in live mode
 - [x]Startup banner indicates whether system is in dry-run or live mode
 - [x]Evaluation API response includes `dry_run: boolean` reflecting actual mode
@@ -355,64 +358,73 @@ export class ActionExecutorService {
   constructor(
     private readonly radarrClient: RadarrClient,
     private readonly sonarrClient: SonarrClient,
-    private readonly auditService: AuditService,
   ) {}
 
   /**
    * Execute resolved actions against Radarr/Sonarr.
-   * In dry-run mode, this is a no-op — results pass through unchanged.
+   * In dry-run mode, every result is marked as 'skipped' with no API calls.
    * In live mode, each actionable item is executed sequentially.
    */
   async execute(
     results: EvaluationItemResult[],
     items: UnifiedMedia[],
     dryRun: boolean,
-    evaluationId: string,
-    reasoningCache: Map<string, string>,
-  ): Promise<EvaluationItemResult[]> {
-    if (dryRun) return results;
+  ): Promise<{
+    results: EvaluationItemResult[];
+    executionSummary?: ExecutionSummary;
+  }> {
+    if (dryRun)
+      return {
+        results: results.map(r => ({ ...r, execution_status: 'skipped' as const })),
+      };
 
-    const itemsByExternalId = new Map(
-      items.map(i => [i.type === 'movie' ? i.tmdb_id : i.tvdb_id, i]),
+    const itemsByInternalId = new Map(
+      items.map(item => [buildInternalId(item), item]),
     );
 
     const executed: EvaluationItemResult[] = [];
+    const counts: Record<Action, number> = { keep: 0, unmonitor: 0, delete: 0 };
+    let failedCount = 0;
 
     for (const result of results) {
       if (!result.resolved_action || result.resolved_action === 'keep') {
-        executed.push(result);
+        executed.push({ ...result, execution_status: 'skipped' });
         continue;
       }
 
-      const item = itemsByExternalId.get(result.external_id);
+      const item = itemsByInternalId.get(result.internal_id);
       if (!item) {
         executed.push({
           ...result,
           execution_status: 'failed',
           execution_error: 'Item not found in hydrated data',
         });
+        failedCount++;
         continue;
       }
 
       try {
         await this.executeAction(item, result.resolved_action);
         executed.push({ ...result, execution_status: 'success' });
+        counts[result.resolved_action]++;
       } catch (error) {
-        const is404 = /* check for 404 status */;
-        if (is404) {
-          this.logger.warn(`${result.resolved_action} ${result.title}: 404 — already removed`);
-          executed.push({ ...result, execution_status: 'success' });
+        if (this.isNotFound(error)) {
+          this.logger.warn(
+            `${result.resolved_action} "${result.title}": 404 — already removed`,
+          );
         } else {
-          executed.push({
-            ...result,
-            execution_status: 'failed',
-            execution_error: error instanceof Error ? error.message : 'Unknown error',
-          });
+          const message = error instanceof Error ? error.message : 'Unknown error';
+          this.logger.error(`Failed to ${result.resolved_action} "${result.title}": ${message}`);
+          executed.push({ ...result, execution_status: 'failed', execution_error: message });
+          failedCount++;
         }
       }
     }
 
-    return executed;
+    return {
+      results: executed,
+      executionSummary: { actions_executed: counts, actions_failed: failedCount },
+    };
   }
 }
 ```

--- a/src/config/config.schema.ts
+++ b/src/config/config.schema.ts
@@ -56,6 +56,7 @@ export interface ServiceConfig {
 }
 
 export interface RoombarrConfig {
+  dry_run: boolean;
   services: {
     sonarr?: ServiceConfig;
     radarr?: ServiceConfig;
@@ -129,6 +130,7 @@ const servicesSchema = z.object({
 });
 
 export const configSchema = z.object({
+  dry_run: z.boolean().default(true),
   services: servicesSchema,
   schedule: z.string().min(1),
   performance: performanceSchema,

--- a/src/config/config.service.test.ts
+++ b/src/config/config.service.test.ts
@@ -720,6 +720,57 @@ describe('validateConfig (cross-validation)', () => {
     expect(errors).toEqual([]);
   });
 
+  test('passes with radarr.has_file field', () => {
+    const config = parse({
+      rules: [
+        {
+          name: 'Has file rule',
+          target: 'radarr',
+          conditions: {
+            operator: 'AND',
+            children: [
+              {
+                field: 'radarr.has_file',
+                operator: 'equals',
+                value: true,
+              },
+            ],
+          },
+          action: 'delete',
+        },
+      ],
+    });
+    const errors = validateConfig(config);
+    expect(errors).toEqual([]);
+  });
+
+  test('passes with sonarr.season.has_file field', () => {
+    const config = parse({
+      services: {
+        sonarr: { base_url: 'http://localhost:8989', api_key: 'key' },
+      },
+      rules: [
+        {
+          name: 'Season has file rule',
+          target: 'sonarr',
+          conditions: {
+            operator: 'AND',
+            children: [
+              {
+                field: 'sonarr.season.has_file',
+                operator: 'equals',
+                value: true,
+              },
+            ],
+          },
+          action: 'delete',
+        },
+      ],
+    });
+    const errors = validateConfig(config);
+    expect(errors).toEqual([]);
+  });
+
   test('passes with sonarr season fields', () => {
     const config = parse({
       services: {

--- a/src/config/field-registry.ts
+++ b/src/config/field-registry.ts
@@ -23,6 +23,7 @@ const radarrFields: Record<string, FieldDefinition> = {
   'radarr.digital_release': { type: 'date', service: 'radarr' },
   'radarr.physical_release': { type: 'date', service: 'radarr' },
   'radarr.size_on_disk': { type: 'number', service: 'radarr' },
+  'radarr.has_file': { type: 'boolean', service: 'radarr' },
   'radarr.monitored': { type: 'boolean', service: 'radarr' },
   'radarr.tags': { type: 'array', service: 'radarr' },
   'radarr.genres': { type: 'array', service: 'radarr' },
@@ -41,6 +42,7 @@ const sonarrFields: Record<string, FieldDefinition> = {
   'sonarr.season.season_number': { type: 'number', service: 'sonarr' },
   'sonarr.season.episode_count': { type: 'number', service: 'sonarr' },
   'sonarr.season.episode_file_count': { type: 'number', service: 'sonarr' },
+  'sonarr.season.has_file': { type: 'boolean', service: 'sonarr' },
   'sonarr.season.size_on_disk': { type: 'number', service: 'sonarr' },
 };
 

--- a/src/evaluation/evaluation.controller.ts
+++ b/src/evaluation/evaluation.controller.ts
@@ -66,7 +66,7 @@ export class EvaluationController {
       completed_at: run.completed_at,
       summary: run.summary,
       results: run.results,
-      dry_run: true,
+      dry_run: run.dry_run,
     });
   }
 }

--- a/src/evaluation/evaluation.module.ts
+++ b/src/evaluation/evaluation.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '../config/config.module.js';
+import { ExecutionModule } from '../execution/execution.module.js';
 import { MediaModule } from '../media/media.module.js';
 import { RulesModule } from '../rules/rules.module.js';
 import { SnapshotModule } from '../snapshot/snapshot.module.js';
@@ -7,7 +8,13 @@ import { EvaluationController } from './evaluation.controller.js';
 import { EvaluationService } from './evaluation.service.js';
 
 @Module({
-  imports: [ConfigModule, MediaModule, RulesModule, SnapshotModule],
+  imports: [
+    ConfigModule,
+    MediaModule,
+    RulesModule,
+    SnapshotModule,
+    ExecutionModule,
+  ],
   controllers: [EvaluationController],
   providers: [EvaluationService],
 })

--- a/src/evaluation/evaluation.service.test.ts
+++ b/src/evaluation/evaluation.service.test.ts
@@ -59,6 +59,7 @@ const testMovie: UnifiedMovie = {
 const testEvaluationResult: EvaluationItemResult = {
   title: 'The Matrix (1999)',
   type: 'movie',
+  internal_id: 'movie:42',
   external_id: 603,
   matched_rules: ['Delete old movies'],
   resolved_action: 'delete',
@@ -138,6 +139,7 @@ describe('EvaluationService', () => {
       const unmatchedResult: EvaluationItemResult = {
         title: 'Unmatched Movie',
         type: 'movie',
+        internal_id: 'movie:999',
         external_id: 999,
         matched_rules: [],
         resolved_action: null,

--- a/src/evaluation/evaluation.service.test.ts
+++ b/src/evaluation/evaluation.service.test.ts
@@ -40,6 +40,7 @@ const testMovie: UnifiedMovie = {
   radarr: {
     added: '2024-01-01T00:00:00Z',
     size_on_disk: 5_000_000_000,
+    has_file: true,
     monitored: true,
     tags: [],
     genres: ['action'],

--- a/src/evaluation/evaluation.service.test.ts
+++ b/src/evaluation/evaluation.service.test.ts
@@ -8,6 +8,7 @@ import type { UnifiedMovie } from '../shared/types.js';
 import { EvaluationService } from './evaluation.service.js';
 
 const testConfig: RoombarrConfig = {
+  dry_run: true,
   services: {
     radarr: { base_url: 'http://radarr:7878', api_key: 'test' },
   },
@@ -31,6 +32,7 @@ const testConfig: RoombarrConfig = {
 
 const testMovie: UnifiedMovie = {
   type: 'movie',
+  radarr_id: 42,
   tmdb_id: 603,
   imdb_id: 'tt0133093',
   title: 'The Matrix (1999)',

--- a/src/evaluation/evaluation.service.test.ts
+++ b/src/evaluation/evaluation.service.test.ts
@@ -133,6 +133,12 @@ describe('EvaluationService', () => {
       expect(run.results[0].title).toBe('The Matrix (1999)');
       expect(mediaService.hydrate).toHaveBeenCalledTimes(1);
       expect(rulesService.evaluate).toHaveBeenCalledTimes(1);
+      expect(actionExecutor.execute).toHaveBeenCalledTimes(1);
+      expect(actionExecutor.execute).toHaveBeenCalledWith(
+        [testEvaluationResult],
+        [testMovie],
+        testConfig.dry_run,
+      );
     });
 
     test('filters out unmatched items from results', async () => {

--- a/src/evaluation/evaluation.service.test.ts
+++ b/src/evaluation/evaluation.service.test.ts
@@ -83,6 +83,7 @@ describe('EvaluationService', () => {
   let rulesService: { evaluate: ReturnType<typeof mock> };
   let snapshotService: { snapshot: ReturnType<typeof mock> };
   let stateService: { enrich: ReturnType<typeof mock> };
+  let actionExecutor: { execute: ReturnType<typeof mock> };
   let service: EvaluationService;
 
   beforeEach(() => {
@@ -104,6 +105,9 @@ describe('EvaluationService', () => {
     stateService = {
       enrich: mock((items: any) => items),
     };
+    actionExecutor = {
+      execute: mock((results: any) => Promise.resolve({ results })),
+    };
 
     service = new EvaluationService(
       configService as any,
@@ -111,6 +115,7 @@ describe('EvaluationService', () => {
       rulesService as any,
       snapshotService as any,
       stateService as any,
+      actionExecutor as any,
     );
   });
 

--- a/src/evaluation/evaluation.service.ts
+++ b/src/evaluation/evaluation.service.ts
@@ -67,9 +67,11 @@ export class EvaluationService {
    * The evaluation continues asynchronously.
    */
   startEvaluation(): EvaluationRun {
+    const config = this.configService.getConfig();
     const run: EvaluationRun = {
       run_id: randomUUID(),
       status: 'running',
+      dry_run: config.dry_run,
       started_at: new Date().toISOString(),
       completed_at: null,
       summary: null,
@@ -96,9 +98,11 @@ export class EvaluationService {
    * Returns when complete.
    */
   async runEvaluation(): Promise<EvaluationRun> {
+    const config = this.configService.getConfig();
     const run: EvaluationRun = {
       run_id: randomUUID(),
       status: 'running',
+      dry_run: config.dry_run,
       started_at: new Date().toISOString(),
       completed_at: null,
       summary: null,
@@ -138,6 +142,7 @@ export class EvaluationService {
         enrichedItems,
         rules,
         run.run_id,
+        run.dry_run,
       );
 
       // Step 3: Update run with results

--- a/src/evaluation/evaluation.service.ts
+++ b/src/evaluation/evaluation.service.ts
@@ -165,10 +165,13 @@ export class EvaluationService {
       this.logger.log({
         msg: `Evaluation ${run.run_id} completed`,
         run_id: run.run_id,
+        dry_run: run.dry_run,
         items_evaluated: summary.items_evaluated,
         items_matched: summary.items_matched,
         actions: summary.actions,
         rules_skipped_missing_data: summary.rules_skipped_missing_data,
+        actions_executed: summary.actions_executed ?? null,
+        actions_failed: summary.actions_failed ?? null,
       });
     } catch (error) {
       run.status = 'failed';

--- a/src/evaluation/evaluation.service.ts
+++ b/src/evaluation/evaluation.service.ts
@@ -4,6 +4,7 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import type { Condition, RoombarrConfig } from '../config/config.schema.js';
 import { ConfigService } from '../config/config.service.js';
 import { getServiceFromField } from '../config/field-registry.js';
+import { ActionExecutorService } from '../execution/action-executor.service.js';
 import { MediaService } from '../media/media.service.js';
 import { RulesService } from '../rules/rules.service.js';
 import { SnapshotService } from '../snapshot/snapshot.service.js';
@@ -24,6 +25,7 @@ export class EvaluationService {
     private readonly rulesService: RulesService,
     private readonly snapshotService: SnapshotService,
     private readonly stateService: StateService,
+    private readonly actionExecutor: ActionExecutorService,
   ) {}
 
   /**
@@ -145,11 +147,20 @@ export class EvaluationService {
         run.dry_run,
       );
 
-      // Step 3: Update run with results
+      // Step 5: Execute actions (no-op in dry-run mode)
+      const { results: executedResults, executionSummary } =
+        await this.actionExecutor.execute(results, enrichedItems, run.dry_run);
+
+      if (executionSummary) {
+        summary.actions_executed = executionSummary.actions_executed;
+        summary.actions_failed = executionSummary.actions_failed;
+      }
+
+      // Step 6: Update run with results
       run.status = 'completed';
       run.completed_at = new Date().toISOString();
       run.summary = summary;
-      run.results = results.filter(r => r.resolved_action !== null);
+      run.results = executedResults.filter(r => r.resolved_action !== null);
 
       this.logger.log({
         msg: `Evaluation ${run.run_id} completed`,

--- a/src/evaluation/evaluation.types.ts
+++ b/src/evaluation/evaluation.types.ts
@@ -8,6 +8,7 @@ export type EvaluationStatus = 'running' | 'completed' | 'failed';
 export interface EvaluationRun {
   run_id: string;
   status: EvaluationStatus;
+  dry_run: boolean;
   started_at: string;
   completed_at: string | null;
   summary: EvaluationSummary | null;

--- a/src/execution/action-executor.service.test.ts
+++ b/src/execution/action-executor.service.test.ts
@@ -2,10 +2,11 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { AxiosError } from 'axios';
 import type { RadarrClient } from '../radarr/radarr.client.js';
 import type { EvaluationItemResult } from '../rules/types.js';
-import type {
-  UnifiedMedia,
-  UnifiedMovie,
-  UnifiedSeason,
+import {
+  buildInternalId,
+  type UnifiedMedia,
+  type UnifiedMovie,
+  type UnifiedSeason,
 } from '../shared/types.js';
 import type { SonarrClient } from '../sonarr/sonarr.client.js';
 import { ActionExecutorService } from './action-executor.service.js';
@@ -74,6 +75,7 @@ function makeResult(
   return {
     title: item.title,
     type: item.type,
+    internal_id: buildInternalId(item),
     external_id: item.type === 'movie' ? item.tmdb_id : item.tvdb_id,
     matched_rules: action ? ['test-rule'] : [],
     resolved_action: action,
@@ -185,7 +187,7 @@ describe('ActionExecutorService', () => {
   });
 
   describe('dry-run mode', () => {
-    test('returns results unchanged when dry_run is true', async () => {
+    test('marks all results as skipped when dry_run is true', async () => {
       const movie = makeMovie();
       const result = makeResult(movie, 'delete');
 
@@ -195,7 +197,7 @@ describe('ActionExecutorService', () => {
         true,
       );
 
-      expect(results).toEqual([result]);
+      expect(results[0].execution_status).toBe('skipped');
       expect(executionSummary).toBeUndefined();
       expect(radarrClient.deleteMovie).not.toHaveBeenCalled();
     });
@@ -280,8 +282,7 @@ describe('ActionExecutorService', () => {
 
       expect(radarrClient.deleteMovie).not.toHaveBeenCalled();
       expect(radarrClient.fetchMovie).not.toHaveBeenCalled();
-      expect(results[0]).toEqual(result);
-      expect(results[0].execution_status).toBeUndefined();
+      expect(results[0].execution_status).toBe('skipped');
     });
 
     test('skips execution for null actions', async () => {
@@ -291,7 +292,7 @@ describe('ActionExecutorService', () => {
       const { results } = await service.execute([result], [movie], false);
 
       expect(radarrClient.deleteMovie).not.toHaveBeenCalled();
-      expect(results[0]).toEqual(result);
+      expect(results[0].execution_status).toBe('skipped');
     });
   });
 

--- a/src/execution/action-executor.service.test.ts
+++ b/src/execution/action-executor.service.test.ts
@@ -297,7 +297,7 @@ describe('ActionExecutorService', () => {
   });
 
   describe('error handling', () => {
-    test('treats 404 as success', async () => {
+    test('logs 404 as warning without counting as success or failure', async () => {
       radarrClient.deleteMovie = mock(() => Promise.reject(make404Error()));
       const movie = makeMovie();
       const result = makeResult(movie, 'delete');
@@ -308,8 +308,8 @@ describe('ActionExecutorService', () => {
         false,
       );
 
-      expect(results[0].execution_status).toBe('success');
-      expect(executionSummary?.actions_executed.delete).toBe(1);
+      expect(results).toHaveLength(0);
+      expect(executionSummary?.actions_executed.delete).toBe(0);
       expect(executionSummary?.actions_failed).toBe(0);
     });
 

--- a/src/execution/action-executor.service.test.ts
+++ b/src/execution/action-executor.service.test.ts
@@ -247,6 +247,25 @@ describe('ActionExecutorService', () => {
       expect(results[0].execution_status).toBe('success');
     });
 
+    test('continues deleting remaining files when individual file returns 404', async () => {
+      let callCount = 0;
+      sonarrClient.deleteEpisodeFile = mock(() => {
+        callCount++;
+        if (callCount === 1) return Promise.reject(make404Error());
+        return Promise.resolve();
+      });
+
+      const season = makeSeason();
+      const result = makeResult(season, 'delete');
+
+      const { results } = await service.execute([result], [season], false);
+
+      expect(sonarrClient.deleteEpisodeFile).toHaveBeenCalledTimes(2);
+      expect(sonarrClient.deleteEpisodeFile).toHaveBeenCalledWith(1);
+      expect(sonarrClient.deleteEpisodeFile).toHaveBeenCalledWith(2);
+      expect(results[0].execution_status).toBe('success');
+    });
+
     test('handles season with no episode files gracefully', async () => {
       sonarrClient.fetchEpisodeFiles = mock(() => Promise.resolve([]));
       const season = makeSeason();

--- a/src/execution/action-executor.service.test.ts
+++ b/src/execution/action-executor.service.test.ts
@@ -22,6 +22,7 @@ function makeMovie(overrides: Record<string, any> = {}): UnifiedMovie {
     radarr: {
       added: '2024-01-01T00:00:00Z',
       size_on_disk: 8_500_000_000,
+      has_file: true,
       monitored: true,
       tags: [],
       genres: ['action'],
@@ -58,6 +59,7 @@ function makeSeason(overrides: Record<string, any> = {}): UnifiedSeason {
         monitored: true,
         episode_count: 7,
         episode_file_count: 7,
+        has_file: true,
         size_on_disk: 10_000_000_000,
       },
     },

--- a/src/execution/action-executor.service.test.ts
+++ b/src/execution/action-executor.service.test.ts
@@ -1,0 +1,384 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { AxiosError } from 'axios';
+import type { RadarrClient } from '../radarr/radarr.client.js';
+import type { EvaluationItemResult } from '../rules/types.js';
+import type {
+  UnifiedMedia,
+  UnifiedMovie,
+  UnifiedSeason,
+} from '../shared/types.js';
+import type { SonarrClient } from '../sonarr/sonarr.client.js';
+import { ActionExecutorService } from './action-executor.service.js';
+
+function makeMovie(overrides: Record<string, any> = {}): UnifiedMovie {
+  return {
+    type: 'movie',
+    radarr_id: 42,
+    tmdb_id: 603,
+    imdb_id: 'tt0133093',
+    title: 'The Matrix',
+    year: 1999,
+    radarr: {
+      added: '2024-01-01T00:00:00Z',
+      size_on_disk: 8_500_000_000,
+      monitored: true,
+      tags: [],
+      genres: ['action'],
+      status: 'released',
+      year: 1999,
+      digital_release: null,
+      physical_release: null,
+      path: '/movies/The Matrix',
+      on_import_list: false,
+      import_list_ids: [],
+    },
+    state: null,
+    jellyfin: null,
+    jellyseerr: null,
+    ...overrides,
+  };
+}
+
+function makeSeason(overrides: Record<string, any> = {}): UnifiedSeason {
+  return {
+    type: 'season',
+    sonarr_series_id: 10,
+    tvdb_id: 100,
+    title: 'Breaking Bad - S01',
+    year: 2008,
+    sonarr: {
+      tags: [],
+      genres: ['drama'],
+      status: 'ended',
+      year: 2008,
+      path: '/tv/Breaking Bad',
+      season: {
+        season_number: 1,
+        monitored: true,
+        episode_count: 7,
+        episode_file_count: 7,
+        size_on_disk: 10_000_000_000,
+      },
+    },
+    state: null,
+    jellyfin: null,
+    jellyseerr: null,
+    ...overrides,
+  };
+}
+
+function makeResult(
+  item: UnifiedMedia,
+  action: 'delete' | 'unmonitor' | 'keep' | null,
+): EvaluationItemResult {
+  return {
+    title: item.title,
+    type: item.type,
+    external_id: item.type === 'movie' ? item.tmdb_id : item.tvdb_id,
+    matched_rules: action ? ['test-rule'] : [],
+    resolved_action: action,
+    dry_run: false,
+  };
+}
+
+function make404Error(): AxiosError {
+  const error = new AxiosError('Not Found');
+  error.response = {
+    status: 404,
+    statusText: 'Not Found',
+    headers: {},
+    config: {} as any,
+    data: {},
+  };
+  return error;
+}
+
+describe('ActionExecutorService', () => {
+  let radarrClient: {
+    deleteMovie: ReturnType<typeof mock>;
+    fetchMovie: ReturnType<typeof mock>;
+    updateMovie: ReturnType<typeof mock>;
+  };
+  let sonarrClient: {
+    fetchEpisodeFiles: ReturnType<typeof mock>;
+    deleteEpisodeFile: ReturnType<typeof mock>;
+    fetchSeriesById: ReturnType<typeof mock>;
+    updateSeries: ReturnType<typeof mock>;
+  };
+  let service: ActionExecutorService;
+
+  beforeEach(() => {
+    radarrClient = {
+      deleteMovie: mock(() => Promise.resolve()),
+      fetchMovie: mock(() =>
+        Promise.resolve({
+          id: 42,
+          title: 'The Matrix',
+          tmdbId: 603,
+          imdbId: 'tt0133093',
+          year: 1999,
+          path: '/movies/The Matrix',
+          status: 'released',
+          genres: ['action'],
+          tags: [],
+          monitored: true,
+          sizeOnDisk: 8_500_000_000,
+          added: '2024-01-01T00:00:00Z',
+          digitalRelease: null,
+          physicalRelease: null,
+        }),
+      ),
+      updateMovie: mock(() => Promise.resolve()),
+    };
+    sonarrClient = {
+      fetchEpisodeFiles: mock(() =>
+        Promise.resolve([
+          {
+            id: 1,
+            seriesId: 10,
+            seasonNumber: 1,
+            path: '/ep1.mkv',
+            size: 1_000_000_000,
+          },
+          {
+            id: 2,
+            seriesId: 10,
+            seasonNumber: 1,
+            path: '/ep2.mkv',
+            size: 1_000_000_000,
+          },
+          {
+            id: 3,
+            seriesId: 10,
+            seasonNumber: 2,
+            path: '/ep3.mkv',
+            size: 1_000_000_000,
+          },
+        ]),
+      ),
+      deleteEpisodeFile: mock(() => Promise.resolve()),
+      fetchSeriesById: mock(() =>
+        Promise.resolve({
+          id: 10,
+          title: 'Breaking Bad',
+          tvdbId: 100,
+          imdbId: null,
+          year: 2008,
+          path: '/tv/Breaking Bad',
+          status: 'ended',
+          genres: ['drama'],
+          tags: [],
+          monitored: true,
+          seasons: [
+            { seasonNumber: 1, monitored: true },
+            { seasonNumber: 2, monitored: true },
+          ],
+        }),
+      ),
+      updateSeries: mock(() => Promise.resolve()),
+    };
+
+    service = new ActionExecutorService(
+      radarrClient as unknown as RadarrClient,
+      sonarrClient as unknown as SonarrClient,
+    );
+  });
+
+  describe('dry-run mode', () => {
+    test('returns results unchanged when dry_run is true', async () => {
+      const movie = makeMovie();
+      const result = makeResult(movie, 'delete');
+
+      const { results, executionSummary } = await service.execute(
+        [result],
+        [movie],
+        true,
+      );
+
+      expect(results).toEqual([result]);
+      expect(executionSummary).toBeUndefined();
+      expect(radarrClient.deleteMovie).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Radarr delete', () => {
+    test('calls deleteMovie with radarr_id', async () => {
+      const movie = makeMovie();
+      const result = makeResult(movie, 'delete');
+
+      const { results } = await service.execute([result], [movie], false);
+
+      expect(radarrClient.deleteMovie).toHaveBeenCalledWith(42);
+      expect(results[0].execution_status).toBe('success');
+    });
+  });
+
+  describe('Radarr unmonitor', () => {
+    test('re-fetches movie and PUTs with monitored: false', async () => {
+      const movie = makeMovie();
+      const result = makeResult(movie, 'unmonitor');
+
+      const { results } = await service.execute([result], [movie], false);
+
+      expect(radarrClient.fetchMovie).toHaveBeenCalledWith(42);
+      expect(radarrClient.updateMovie).toHaveBeenCalledTimes(1);
+      const putBody = radarrClient.updateMovie.mock.calls[0][1];
+      expect(putBody.monitored).toBe(false);
+      expect(results[0].execution_status).toBe('success');
+    });
+  });
+
+  describe('Sonarr season delete', () => {
+    test('fetches episode files, filters by season, deletes each', async () => {
+      const season = makeSeason();
+      const result = makeResult(season, 'delete');
+
+      const { results } = await service.execute([result], [season], false);
+
+      expect(sonarrClient.fetchEpisodeFiles).toHaveBeenCalledWith(10);
+      // Only season 1 files (ids 1 and 2), not season 2 (id 3)
+      expect(sonarrClient.deleteEpisodeFile).toHaveBeenCalledTimes(2);
+      expect(sonarrClient.deleteEpisodeFile).toHaveBeenCalledWith(1);
+      expect(sonarrClient.deleteEpisodeFile).toHaveBeenCalledWith(2);
+      expect(results[0].execution_status).toBe('success');
+    });
+
+    test('handles season with no episode files gracefully', async () => {
+      sonarrClient.fetchEpisodeFiles = mock(() => Promise.resolve([]));
+      const season = makeSeason();
+      const result = makeResult(season, 'delete');
+
+      const { results } = await service.execute([result], [season], false);
+
+      expect(sonarrClient.deleteEpisodeFile).not.toHaveBeenCalled();
+      expect(results[0].execution_status).toBe('success');
+    });
+  });
+
+  describe('Sonarr season unmonitor', () => {
+    test('re-fetches series and PUTs with season monitored: false', async () => {
+      const season = makeSeason();
+      const result = makeResult(season, 'unmonitor');
+
+      const { results } = await service.execute([result], [season], false);
+
+      expect(sonarrClient.fetchSeriesById).toHaveBeenCalledWith(10);
+      expect(sonarrClient.updateSeries).toHaveBeenCalledTimes(1);
+      const putBody = sonarrClient.updateSeries.mock.calls[0][1];
+      expect(putBody.seasons[0].monitored).toBe(false);
+      expect(putBody.seasons[1].monitored).toBe(true); // season 2 unchanged
+      expect(results[0].execution_status).toBe('success');
+    });
+  });
+
+  describe('keep actions', () => {
+    test('skips execution for keep actions', async () => {
+      const movie = makeMovie();
+      const result = makeResult(movie, 'keep');
+
+      const { results } = await service.execute([result], [movie], false);
+
+      expect(radarrClient.deleteMovie).not.toHaveBeenCalled();
+      expect(radarrClient.fetchMovie).not.toHaveBeenCalled();
+      expect(results[0]).toEqual(result);
+      expect(results[0].execution_status).toBeUndefined();
+    });
+
+    test('skips execution for null actions', async () => {
+      const movie = makeMovie();
+      const result = makeResult(movie, null);
+
+      const { results } = await service.execute([result], [movie], false);
+
+      expect(radarrClient.deleteMovie).not.toHaveBeenCalled();
+      expect(results[0]).toEqual(result);
+    });
+  });
+
+  describe('error handling', () => {
+    test('treats 404 as success', async () => {
+      radarrClient.deleteMovie = mock(() => Promise.reject(make404Error()));
+      const movie = makeMovie();
+      const result = makeResult(movie, 'delete');
+
+      const { results, executionSummary } = await service.execute(
+        [result],
+        [movie],
+        false,
+      );
+
+      expect(results[0].execution_status).toBe('success');
+      expect(executionSummary?.actions_executed.delete).toBe(1);
+      expect(executionSummary?.actions_failed).toBe(0);
+    });
+
+    test('continues executing after non-404 error', async () => {
+      const movie1 = makeMovie({ radarr_id: 1, tmdb_id: 100 });
+      const movie2 = makeMovie({ radarr_id: 2, tmdb_id: 200 });
+
+      // First call fails with 500, second succeeds
+      let callCount = 0;
+      radarrClient.deleteMovie = mock(() => {
+        callCount++;
+        if (callCount === 1)
+          return Promise.reject(new Error('Internal Server Error'));
+        return Promise.resolve();
+      });
+
+      const results = [
+        makeResult(movie1, 'delete'),
+        makeResult(movie2, 'delete'),
+      ];
+
+      const { results: executed, executionSummary } = await service.execute(
+        results,
+        [movie1, movie2],
+        false,
+      );
+
+      expect(executed[0].execution_status).toBe('failed');
+      expect(executed[0].execution_error).toBe('Internal Server Error');
+      expect(executed[1].execution_status).toBe('success');
+      expect(executionSummary?.actions_executed.delete).toBe(1);
+      expect(executionSummary?.actions_failed).toBe(1);
+    });
+
+    test('reports failure when item not found in hydrated data', async () => {
+      const movie = makeMovie();
+      const result = makeResult(movie, 'delete');
+
+      // Pass empty items array — item won't be found
+      const { results } = await service.execute([result], [], false);
+
+      expect(results[0].execution_status).toBe('failed');
+      expect(results[0].execution_error).toBe(
+        'Item not found in hydrated data',
+      );
+    });
+  });
+
+  describe('execution summary', () => {
+    test('tracks counts across multiple actions', async () => {
+      const movie1 = makeMovie({ radarr_id: 1, tmdb_id: 100 });
+      const movie2 = makeMovie({ radarr_id: 2, tmdb_id: 200 });
+      const season = makeSeason();
+
+      const results = [
+        makeResult(movie1, 'delete'),
+        makeResult(movie2, 'unmonitor'),
+        makeResult(season, 'delete'),
+      ];
+
+      const { executionSummary } = await service.execute(
+        results,
+        [movie1, movie2, season],
+        false,
+      );
+
+      expect(executionSummary).toBeDefined();
+      expect(executionSummary?.actions_executed.delete).toBe(2);
+      expect(executionSummary?.actions_executed.unmonitor).toBe(1);
+      expect(executionSummary?.actions_failed).toBe(0);
+    });
+  });
+});

--- a/src/execution/action-executor.service.test.ts
+++ b/src/execution/action-executor.service.test.ts
@@ -347,6 +347,32 @@ describe('ActionExecutorService', () => {
       expect(executionSummary?.actions_failed).toBe(1);
     });
 
+    test('includes not_found alongside successful items in mixed batch', async () => {
+      const movie1 = makeMovie({ radarr_id: 1, tmdb_id: 100 });
+      const movie2 = makeMovie({ radarr_id: 2, tmdb_id: 200 });
+
+      // First call returns 404, second succeeds
+      let callCount = 0;
+      radarrClient.deleteMovie = mock(() => {
+        callCount++;
+        if (callCount === 1) return Promise.reject(make404Error());
+        return Promise.resolve();
+      });
+
+      const { results: executed, executionSummary } = await service.execute(
+        [makeResult(movie1, 'delete'), makeResult(movie2, 'delete')],
+        [movie1, movie2],
+        false,
+      );
+
+      expect(executed).toHaveLength(2);
+      expect(executed[0].execution_status).toBe('not_found');
+      expect(executed[0].execution_error).toBeUndefined();
+      expect(executed[1].execution_status).toBe('success');
+      expect(executionSummary?.actions_executed.delete).toBe(1);
+      expect(executionSummary?.actions_failed).toBe(0);
+    });
+
     test('reports failure when item not found in hydrated data', async () => {
       const movie = makeMovie();
       const result = makeResult(movie, 'delete');

--- a/src/execution/action-executor.service.test.ts
+++ b/src/execution/action-executor.service.test.ts
@@ -310,7 +310,8 @@ describe('ActionExecutorService', () => {
         false,
       );
 
-      expect(results).toHaveLength(0);
+      expect(results).toHaveLength(1);
+      expect(results[0].execution_status).toBe('not_found');
       expect(executionSummary?.actions_executed.delete).toBe(0);
       expect(executionSummary?.actions_failed).toBe(0);
     });

--- a/src/execution/action-executor.service.ts
+++ b/src/execution/action-executor.service.ts
@@ -76,6 +76,7 @@ export class ActionExecutorService {
           this.logger.warn(
             `${result.resolved_action} "${result.title}": 404 — already removed`,
           );
+          executed.push({ ...result, execution_status: 'not_found' });
         } else {
           const message =
             error instanceof Error ? error.message : 'Unknown error';

--- a/src/execution/action-executor.service.ts
+++ b/src/execution/action-executor.service.ts
@@ -106,14 +106,20 @@ export class ActionExecutorService {
     item: UnifiedMedia,
     action: Action,
   ): Promise<void> {
-    if (item.type === 'movie') {
-      return action === 'delete'
-        ? this.deleteMovie(item)
-        : this.unmonitorMovie(item);
+    switch (action) {
+      case 'delete':
+        return item.type === 'movie'
+          ? this.deleteMovie(item)
+          : this.deleteSeasonFiles(item);
+      case 'unmonitor':
+        return item.type === 'movie'
+          ? this.unmonitorMovie(item)
+          : this.unmonitorSeason(item);
+      case 'keep':
+        return;
+      default:
+        throw new Error(`Unknown action: ${action satisfies never}`);
     }
-    return action === 'delete'
-      ? this.deleteSeasonFiles(item)
-      : this.unmonitorSeason(item);
   }
 
   private async deleteMovie(movie: UnifiedMovie): Promise<void> {
@@ -159,22 +165,30 @@ export class ActionExecutorService {
       return;
     }
 
+    let deletedCount = 0;
+    let alreadyRemovedCount = 0;
+
     for (const file of seasonFiles) {
       try {
         await this.sonarrClient.deleteEpisodeFile(file.id);
+        deletedCount++;
       } catch (error) {
         if (this.isNotFound(error)) {
           this.logger.warn(
             `Episode file ${file.id} for "${season.title}" S${String(seasonNumber).padStart(2, '0')}: 404 — already removed`,
           );
+          alreadyRemovedCount++;
           continue;
         }
         throw error;
       }
     }
 
+    const parts = [`Deleted ${deletedCount} episode files`];
+    if (alreadyRemovedCount > 0)
+      parts.push(`${alreadyRemovedCount} already removed`);
     this.logger.log(
-      `Deleted ${seasonFiles.length} episode files for "${season.title}" S${String(seasonNumber).padStart(2, '0')}`,
+      `${parts.join(', ')} for "${season.title}" S${String(seasonNumber).padStart(2, '0')}`,
     );
   }
 

--- a/src/execution/action-executor.service.ts
+++ b/src/execution/action-executor.service.ts
@@ -76,8 +76,6 @@ export class ActionExecutorService {
           this.logger.warn(
             `${result.resolved_action} "${result.title}": 404 — already removed`,
           );
-          executed.push({ ...result, execution_status: 'success' });
-          counts[result.resolved_action]++;
         } else {
           const message =
             error instanceof Error ? error.message : 'Unknown error';
@@ -161,7 +159,17 @@ export class ActionExecutorService {
     }
 
     for (const file of seasonFiles) {
-      await this.sonarrClient.deleteEpisodeFile(file.id);
+      try {
+        await this.sonarrClient.deleteEpisodeFile(file.id);
+      } catch (error) {
+        if (this.isNotFound(error)) {
+          this.logger.warn(
+            `Episode file ${file.id} for "${season.title}" S${String(seasonNumber).padStart(2, '0')}: 404 — already removed`,
+          );
+          continue;
+        }
+        throw error;
+      }
     }
 
     this.logger.log(

--- a/src/execution/action-executor.service.ts
+++ b/src/execution/action-executor.service.ts
@@ -1,0 +1,199 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AxiosError } from 'axios';
+import type { Action } from '../config/config.schema.js';
+import { RadarrClient } from '../radarr/radarr.client.js';
+import type { EvaluationItemResult } from '../rules/types.js';
+import type {
+  UnifiedMedia,
+  UnifiedMovie,
+  UnifiedSeason,
+} from '../shared/types.js';
+import { SonarrClient } from '../sonarr/sonarr.client.js';
+import type { ExecutionSummary } from './execution.types.js';
+
+@Injectable()
+export class ActionExecutorService {
+  private readonly logger = new Logger(ActionExecutorService.name);
+
+  constructor(
+    private readonly radarrClient: RadarrClient,
+    private readonly sonarrClient: SonarrClient,
+  ) {}
+
+  /**
+   * Execute resolved actions against Radarr/Sonarr.
+   * In dry-run mode, this is a no-op — results pass through unchanged.
+   * In live mode, each actionable item is executed sequentially.
+   */
+  async execute(
+    results: EvaluationItemResult[],
+    items: UnifiedMedia[],
+    dryRun: boolean,
+  ): Promise<{
+    results: EvaluationItemResult[];
+    executionSummary?: ExecutionSummary;
+  }> {
+    if (dryRun) return { results };
+
+    const itemsByExternalId = new Map(
+      items.map(item => [
+        item.type === 'movie' ? item.tmdb_id : item.tvdb_id,
+        item,
+      ]),
+    );
+
+    const executed: EvaluationItemResult[] = [];
+    const counts: Record<Action, number> = { keep: 0, unmonitor: 0, delete: 0 };
+    let failedCount = 0;
+
+    for (const result of results) {
+      if (!result.resolved_action || result.resolved_action === 'keep') {
+        executed.push(result);
+        continue;
+      }
+
+      const item = itemsByExternalId.get(result.external_id);
+      if (!item) {
+        executed.push({
+          ...result,
+          execution_status: 'failed',
+          execution_error: 'Item not found in hydrated data',
+        });
+        failedCount++;
+        continue;
+      }
+
+      try {
+        await this.executeAction(item, result.resolved_action);
+        executed.push({ ...result, execution_status: 'success' });
+        counts[result.resolved_action]++;
+      } catch (error) {
+        if (this.isNotFound(error)) {
+          this.logger.warn(
+            `${result.resolved_action} "${result.title}": 404 — already removed`,
+          );
+          executed.push({ ...result, execution_status: 'success' });
+          counts[result.resolved_action]++;
+        } else {
+          const message =
+            error instanceof Error ? error.message : 'Unknown error';
+          this.logger.error(
+            `Failed to ${result.resolved_action} "${result.title}": ${message}`,
+          );
+          executed.push({
+            ...result,
+            execution_status: 'failed',
+            execution_error: message,
+          });
+          failedCount++;
+        }
+      }
+    }
+
+    return {
+      results: executed,
+      executionSummary: {
+        actions_executed: counts,
+        actions_failed: failedCount,
+      },
+    };
+  }
+
+  private async executeAction(
+    item: UnifiedMedia,
+    action: Action,
+  ): Promise<void> {
+    if (item.type === 'movie') {
+      return action === 'delete'
+        ? this.deleteMovie(item)
+        : this.unmonitorMovie(item);
+    }
+    return action === 'delete'
+      ? this.deleteSeasonFiles(item)
+      : this.unmonitorSeason(item);
+  }
+
+  private async deleteMovie(movie: UnifiedMovie): Promise<void> {
+    this.logger.log(
+      `Deleting movie "${movie.title}" (radarr_id: ${movie.radarr_id})`,
+    );
+    await this.radarrClient.deleteMovie(movie.radarr_id);
+  }
+
+  /**
+   * Unmonitor a movie by re-fetching the full resource from Radarr,
+   * flipping `monitored` to false, and PUTting the full body back.
+   * This avoids metadata corruption from partial request bodies.
+   */
+  private async unmonitorMovie(movie: UnifiedMovie): Promise<void> {
+    this.logger.log(
+      `Unmonitoring movie "${movie.title}" (radarr_id: ${movie.radarr_id})`,
+    );
+    const fresh = await this.radarrClient.fetchMovie(movie.radarr_id);
+    fresh.monitored = false;
+    await this.radarrClient.updateMovie(movie.radarr_id, fresh);
+  }
+
+  /**
+   * Delete all episode files for a specific season.
+   * Fetches episode files lazily — only when deletion is actually needed.
+   */
+  private async deleteSeasonFiles(season: UnifiedSeason): Promise<void> {
+    const seasonNumber = season.sonarr.season.season_number;
+    this.logger.log(
+      `Deleting files for "${season.title}" S${String(seasonNumber).padStart(2, '0')} (series_id: ${season.sonarr_series_id})`,
+    );
+
+    const allFiles = await this.sonarrClient.fetchEpisodeFiles(
+      season.sonarr_series_id,
+    );
+    const seasonFiles = allFiles.filter(f => f.seasonNumber === seasonNumber);
+
+    if (seasonFiles.length === 0) {
+      this.logger.warn(
+        `No episode files found for "${season.title}" S${String(seasonNumber).padStart(2, '0')}`,
+      );
+      return;
+    }
+
+    for (const file of seasonFiles) {
+      await this.sonarrClient.deleteEpisodeFile(file.id);
+    }
+
+    this.logger.log(
+      `Deleted ${seasonFiles.length} episode files for "${season.title}" S${String(seasonNumber).padStart(2, '0')}`,
+    );
+  }
+
+  /**
+   * Unmonitor a season by re-fetching the full series from Sonarr,
+   * flipping the target season's `monitored` to false, and PUTting
+   * the full series body back.
+   */
+  private async unmonitorSeason(season: UnifiedSeason): Promise<void> {
+    const seasonNumber = season.sonarr.season.season_number;
+    this.logger.log(
+      `Unmonitoring "${season.title}" S${String(seasonNumber).padStart(2, '0')} (series_id: ${season.sonarr_series_id})`,
+    );
+
+    const freshSeries = await this.sonarrClient.fetchSeriesById(
+      season.sonarr_series_id,
+    );
+    const targetSeason = freshSeries.seasons.find(
+      s => s.seasonNumber === seasonNumber,
+    );
+    if (!targetSeason) {
+      throw new Error(
+        `Season ${seasonNumber} not found on series ${season.sonarr_series_id}`,
+      );
+    }
+
+    targetSeason.monitored = false;
+    await this.sonarrClient.updateSeries(season.sonarr_series_id, freshSeries);
+  }
+
+  /** Check if an error is a 404 Not Found response from Axios. */
+  private isNotFound(error: unknown): boolean {
+    return error instanceof AxiosError && error.response?.status === 404;
+  }
+}

--- a/src/execution/action-executor.service.ts
+++ b/src/execution/action-executor.service.ts
@@ -3,10 +3,11 @@ import { AxiosError } from 'axios';
 import type { Action } from '../config/config.schema.js';
 import { RadarrClient } from '../radarr/radarr.client.js';
 import type { EvaluationItemResult } from '../rules/types.js';
-import type {
-  UnifiedMedia,
-  UnifiedMovie,
-  UnifiedSeason,
+import {
+  buildInternalId,
+  type UnifiedMedia,
+  type UnifiedMovie,
+  type UnifiedSeason,
 } from '../shared/types.js';
 import { SonarrClient } from '../sonarr/sonarr.client.js';
 import type { ExecutionSummary } from './execution.types.js';
@@ -22,7 +23,7 @@ export class ActionExecutorService {
 
   /**
    * Execute resolved actions against Radarr/Sonarr.
-   * In dry-run mode, this is a no-op — results pass through unchanged.
+   * In dry-run mode, every result is marked as 'skipped' with no API calls.
    * In live mode, each actionable item is executed sequentially.
    */
   async execute(
@@ -33,13 +34,16 @@ export class ActionExecutorService {
     results: EvaluationItemResult[];
     executionSummary?: ExecutionSummary;
   }> {
-    if (dryRun) return { results };
+    if (dryRun)
+      return {
+        results: results.map(r => ({
+          ...r,
+          execution_status: 'skipped' as const,
+        })),
+      };
 
-    const itemsByExternalId = new Map(
-      items.map(item => [
-        item.type === 'movie' ? item.tmdb_id : item.tvdb_id,
-        item,
-      ]),
+    const itemsByInternalId = new Map(
+      items.map(item => [buildInternalId(item), item]),
     );
 
     const executed: EvaluationItemResult[] = [];
@@ -48,11 +52,11 @@ export class ActionExecutorService {
 
     for (const result of results) {
       if (!result.resolved_action || result.resolved_action === 'keep') {
-        executed.push(result);
+        executed.push({ ...result, execution_status: 'skipped' });
         continue;
       }
 
-      const item = itemsByExternalId.get(result.external_id);
+      const item = itemsByInternalId.get(result.internal_id);
       if (!item) {
         executed.push({
           ...result,

--- a/src/execution/execution.module.ts
+++ b/src/execution/execution.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { RadarrModule } from '../radarr/radarr.module.js';
+import { SonarrModule } from '../sonarr/sonarr.module.js';
+import { ActionExecutorService } from './action-executor.service.js';
+
+@Module({
+  imports: [RadarrModule, SonarrModule],
+  providers: [ActionExecutorService],
+  exports: [ActionExecutorService],
+})
+export class ExecutionModule {}

--- a/src/execution/execution.types.ts
+++ b/src/execution/execution.types.ts
@@ -1,0 +1,6 @@
+import type { Action } from '../config/config.schema.js';
+
+export interface ExecutionSummary {
+  actions_executed: Record<Action, number>;
+  actions_failed: number;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,24 @@
+import { Logger as NestLogger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { Logger } from 'nestjs-pino';
 import { AppModule } from './app.module.js';
+import { ConfigService } from './config/config.service.js';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
   app.useLogger(app.get(Logger));
   app.enableShutdownHooks();
+
+  const config = app.get(ConfigService);
+  const logger = new NestLogger('Bootstrap');
+  if (config.getConfig().dry_run) {
+    logger.log('DRY RUN MODE — no actions will be executed');
+  } else {
+    logger.warn(
+      'LIVE MODE ENABLED — actions will be executed against Radarr/Sonarr',
+    );
+  }
+
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/media/media.merger.test.ts
+++ b/src/media/media.merger.test.ts
@@ -21,6 +21,7 @@ function makeMovie(tmdbId: number): UnifiedMovie {
     radarr: {
       added: '2024-06-01T12:00:00Z',
       size_on_disk: 5_000_000_000,
+      has_file: true,
       monitored: true,
       tags: [],
       genres: ['action'],
@@ -58,6 +59,7 @@ function makeSeason(tvdbId: number, seasonNumber: number): UnifiedSeason {
         monitored: true,
         episode_count: 10,
         episode_file_count: 10,
+        has_file: true,
         size_on_disk: 10_000_000_000,
       },
     },

--- a/src/media/media.merger.test.ts
+++ b/src/media/media.merger.test.ts
@@ -8,10 +8,12 @@ import type {
 } from '../shared/types.js';
 import { enrichMovies, enrichSeasons } from './media.merger.js';
 
+let nextMovieInternalId = 5000;
+
 function makeMovie(tmdbId: number): UnifiedMovie {
   return {
     type: 'movie',
-    radarr_id: tmdbId + 1000,
+    radarr_id: nextMovieInternalId++,
     tmdb_id: tmdbId,
     imdb_id: `tt${tmdbId}`,
     title: `Movie ${tmdbId}`,
@@ -36,10 +38,12 @@ function makeMovie(tmdbId: number): UnifiedMovie {
   };
 }
 
+let nextSeasonInternalId = 8000;
+
 function makeSeason(tvdbId: number, seasonNumber: number): UnifiedSeason {
   return {
     type: 'season',
-    sonarr_series_id: tvdbId + 2000,
+    sonarr_series_id: nextSeasonInternalId++,
     tvdb_id: tvdbId,
     title: `Series ${tvdbId} - S${String(seasonNumber).padStart(2, '0')}`,
     year: 2024,

--- a/src/media/media.merger.test.ts
+++ b/src/media/media.merger.test.ts
@@ -11,6 +11,7 @@ import { enrichMovies, enrichSeasons } from './media.merger.js';
 function makeMovie(tmdbId: number): UnifiedMovie {
   return {
     type: 'movie',
+    radarr_id: tmdbId + 1000,
     tmdb_id: tmdbId,
     imdb_id: `tt${tmdbId}`,
     title: `Movie ${tmdbId}`,
@@ -38,6 +39,7 @@ function makeMovie(tmdbId: number): UnifiedMovie {
 function makeSeason(tvdbId: number, seasonNumber: number): UnifiedSeason {
   return {
     type: 'season',
+    sonarr_series_id: tvdbId + 2000,
     tvdb_id: tvdbId,
     title: `Series ${tvdbId} - S${String(seasonNumber).padStart(2, '0')}`,
     year: 2024,

--- a/src/media/media.service.test.ts
+++ b/src/media/media.service.test.ts
@@ -19,6 +19,7 @@ function makeMovie(tmdbId: number): UnifiedMovie {
     radarr: {
       added: '2024-06-01T12:00:00Z',
       size_on_disk: 5_000_000_000,
+      has_file: true,
       monitored: true,
       tags: [],
       genres: ['action'],
@@ -54,6 +55,7 @@ function makeSeason(tvdbId: number, seasonNumber: number): UnifiedSeason {
         monitored: true,
         episode_count: 10,
         episode_file_count: 10,
+        has_file: true,
         size_on_disk: 10_000_000_000,
       },
     },

--- a/src/media/media.service.test.ts
+++ b/src/media/media.service.test.ts
@@ -11,6 +11,7 @@ import { MediaService } from './media.service.js';
 function makeMovie(tmdbId: number): UnifiedMovie {
   return {
     type: 'movie',
+    radarr_id: tmdbId + 1000,
     tmdb_id: tmdbId,
     imdb_id: `tt${tmdbId}`,
     title: `Movie ${tmdbId}`,
@@ -38,6 +39,7 @@ function makeMovie(tmdbId: number): UnifiedMovie {
 function makeSeason(tvdbId: number, seasonNumber: number): UnifiedSeason {
   return {
     type: 'season',
+    sonarr_series_id: tvdbId + 2000,
     tvdb_id: tvdbId,
     title: `Series ${tvdbId} - S${String(seasonNumber).padStart(2, '0')}`,
     year: 2024,

--- a/src/radarr/radarr.client.test.ts
+++ b/src/radarr/radarr.client.test.ts
@@ -44,6 +44,7 @@ describe('RadarrClient', () => {
           tags: [1],
           monitored: true,
           sizeOnDisk: 8_500_000_000,
+          hasFile: true,
           added: '2024-06-01T12:00:00Z',
           digitalRelease: null,
           physicalRelease: null,

--- a/src/radarr/radarr.client.ts
+++ b/src/radarr/radarr.client.ts
@@ -31,6 +31,30 @@ export class RadarrClient {
     return data;
   }
 
+  async fetchMovie(movieId: number): Promise<RadarrMovie> {
+    this.logger.debug(`Fetching movie ${movieId} from Radarr`);
+    const { data } = await firstValueFrom(
+      this.http.get<RadarrMovie>(`/api/v3/movie/${movieId}`),
+    );
+    return data;
+  }
+
+  async deleteMovie(movieId: number, deleteFiles = true): Promise<void> {
+    this.logger.debug(
+      `Deleting movie ${movieId} (deleteFiles: ${deleteFiles})`,
+    );
+    await firstValueFrom(
+      this.http.delete(`/api/v3/movie/${movieId}`, {
+        params: { deleteFiles },
+      }),
+    );
+  }
+
+  async updateMovie(movieId: number, body: RadarrMovie): Promise<void> {
+    this.logger.debug(`Updating movie ${movieId}`);
+    await firstValueFrom(this.http.put(`/api/v3/movie/${movieId}`, body));
+  }
+
   async fetchImportListMovies(): Promise<RadarrImportListMovie[]> {
     this.logger.debug('Fetching import list movies from Radarr');
     const { data } = await firstValueFrom(

--- a/src/radarr/radarr.mapper.test.ts
+++ b/src/radarr/radarr.mapper.test.ts
@@ -29,6 +29,7 @@ function makeMovie(overrides: Partial<RadarrMovie> = {}): RadarrMovie {
     genres: ['action', 'sci-fi'],
     tags: [1, 2],
     monitored: true,
+    hasFile: true,
     sizeOnDisk: 8_500_000_000,
     added: '2024-06-01T12:00:00Z',
     digitalRelease: '1999-09-21T00:00:00Z',
@@ -101,6 +102,7 @@ describe('mapMovie', () => {
     expect(result).toEqual({
       added: '2024-06-01T12:00:00Z',
       size_on_disk: 8_500_000_000,
+      has_file: true,
       monitored: true,
       tags: ['keep-forever', 'classics'],
       genres: ['action', 'sci-fi'],
@@ -141,9 +143,10 @@ describe('mapMovie', () => {
   });
 
   test('handles movie with no file on disk', () => {
-    const movie = makeMovie({ sizeOnDisk: 0 });
+    const movie = makeMovie({ hasFile: false, sizeOnDisk: 0 });
     const result = mapMovie(movie, tagMap, emptyImportIndex);
     expect(result.size_on_disk).toBe(0);
+    expect(result.has_file).toBe(false);
   });
 
   test('handles empty genres', () => {

--- a/src/radarr/radarr.mapper.ts
+++ b/src/radarr/radarr.mapper.ts
@@ -53,6 +53,7 @@ export function mapMovie(
   return {
     added: movie.added,
     size_on_disk: movie.sizeOnDisk,
+    has_file: movie.hasFile,
     monitored: movie.monitored,
     tags: resolveTagNames(movie.tags, tagMap),
     genres: movie.genres,

--- a/src/radarr/radarr.module.ts
+++ b/src/radarr/radarr.module.ts
@@ -19,6 +19,6 @@ import { RadarrService } from './radarr.service.js';
     }),
   ],
   providers: [RadarrClient, RadarrService],
-  exports: [RadarrService],
+  exports: [RadarrClient, RadarrService],
 })
 export class RadarrModule {}

--- a/src/radarr/radarr.service.ts
+++ b/src/radarr/radarr.service.ts
@@ -34,6 +34,7 @@ export class RadarrService {
 
     const unified = movies.map(movie => ({
       type: 'movie' as const,
+      radarr_id: movie.id,
       tmdb_id: movie.tmdbId,
       imdb_id: movie.imdbId,
       title: movie.title,

--- a/src/radarr/radarr.types.ts
+++ b/src/radarr/radarr.types.ts
@@ -15,6 +15,7 @@ export interface RadarrMovie {
   genres: string[];
   tags: number[];
   monitored: boolean;
+  hasFile: boolean;
   sizeOnDisk: number;
   added: string;
   digitalRelease: string | null;

--- a/src/rules/field-resolver.test.ts
+++ b/src/rules/field-resolver.test.ts
@@ -13,6 +13,7 @@ function makeMovie(overrides: Record<string, any> = {}): UnifiedMedia {
     radarr: {
       added: '2024-01-01T00:00:00Z',
       size_on_disk: 5_000_000_000,
+      has_file: true,
       monitored: true,
       tags: ['permanent', 'favorite'],
       genres: ['Action', 'Drama'],
@@ -58,6 +59,7 @@ function makeSeason(overrides: Record<string, any> = {}): UnifiedMedia {
         monitored: true,
         episode_count: 10,
         episode_file_count: 10,
+        has_file: true,
         size_on_disk: 15_000_000_000,
       },
     },
@@ -128,6 +130,11 @@ describe('resolveField', () => {
     const season = makeSeason({ jellyseerr: null });
     const result = resolveField(season, 'jellyseerr.requested_by');
     expect(result).toEqual({ value: undefined, resolved: false });
+  });
+
+  test('resolves radarr.has_file boolean field', () => {
+    const result = resolveField(makeMovie(), 'radarr.has_file');
+    expect(result).toEqual({ value: true, resolved: true });
   });
 
   test('resolves deeply nested path', () => {

--- a/src/rules/field-resolver.test.ts
+++ b/src/rules/field-resolver.test.ts
@@ -5,6 +5,7 @@ import { resolveField } from './field-resolver.js';
 function makeMovie(overrides: Record<string, any> = {}): UnifiedMedia {
   return {
     type: 'movie',
+    radarr_id: 501,
     tmdb_id: 12345,
     imdb_id: 'tt1234567',
     title: 'Test Movie',
@@ -42,6 +43,7 @@ function makeMovie(overrides: Record<string, any> = {}): UnifiedMedia {
 function makeSeason(overrides: Record<string, any> = {}): UnifiedMedia {
   return {
     type: 'season',
+    sonarr_series_id: 601,
     tvdb_id: 54321,
     title: 'Test Show',
     year: 2023,

--- a/src/rules/field-resolver.test.ts
+++ b/src/rules/field-resolver.test.ts
@@ -137,6 +137,28 @@ describe('resolveField', () => {
     expect(result).toEqual({ value: true, resolved: true });
   });
 
+  test('resolves radarr.has_file as false without treating it as unresolved', () => {
+    const movie = makeMovie({
+      radarr: {
+        added: '2024-01-01T00:00:00Z',
+        size_on_disk: 0,
+        has_file: false,
+        monitored: true,
+        tags: [],
+        genres: [],
+        status: 'released',
+        year: 2024,
+        digital_release: null,
+        physical_release: null,
+        path: '/movies/test',
+        on_import_list: false,
+        import_list_ids: [],
+      },
+    });
+    const result = resolveField(movie, 'radarr.has_file');
+    expect(result).toEqual({ value: false, resolved: true });
+  });
+
   test('resolves deeply nested path', () => {
     const result = resolveField(makeSeason(), 'sonarr.season.size_on_disk');
     expect(result).toEqual({ value: 15_000_000_000, resolved: true });

--- a/src/rules/rules.service.test.ts
+++ b/src/rules/rules.service.test.ts
@@ -613,4 +613,30 @@ describe('RulesService.evaluate', () => {
       expect(result.dry_run).toBe(true);
     }
   });
+
+  test('all results have dry_run: false when evaluated with false', () => {
+    const items: UnifiedMedia[] = [makeMovie()];
+    const rules = makeRules([
+      {
+        name: 'Any rule',
+        target: 'radarr',
+        conditions: {
+          operator: 'AND',
+          children: [
+            {
+              field: 'radarr.size_on_disk',
+              operator: 'greater_than',
+              value: 0,
+            },
+          ],
+        },
+        action: 'delete',
+      },
+    ]);
+
+    const { results } = service.evaluate(items, rules, 'test-eval-id', false);
+    for (const result of results) {
+      expect(result.dry_run).toBe(false);
+    }
+  });
 });

--- a/src/rules/rules.service.test.ts
+++ b/src/rules/rules.service.test.ts
@@ -19,6 +19,7 @@ function makeMovie(overrides: Record<string, any> = {}): UnifiedMovie {
     radarr: {
       added: '2024-01-01T00:00:00Z',
       size_on_disk: 5_000_000_000,
+      has_file: true,
       monitored: true,
       tags: [],
       genres: ['Action'],
@@ -64,6 +65,7 @@ function makeSeason(overrides: Record<string, any> = {}): UnifiedSeason {
         monitored: true,
         episode_count: 10,
         episode_file_count: 10,
+        has_file: true,
         size_on_disk: 10_000_000_000,
       },
     },

--- a/src/rules/rules.service.test.ts
+++ b/src/rules/rules.service.test.ts
@@ -11,6 +11,7 @@ import { RulesService } from './rules.service.js';
 function makeMovie(overrides: Record<string, any> = {}): UnifiedMovie {
   return {
     type: 'movie',
+    radarr_id: 101,
     tmdb_id: 1,
     imdb_id: 'tt0000001',
     title: 'Test Movie',
@@ -48,6 +49,7 @@ function makeMovie(overrides: Record<string, any> = {}): UnifiedMovie {
 function makeSeason(overrides: Record<string, any> = {}): UnifiedSeason {
   return {
     type: 'season',
+    sonarr_series_id: 201,
     tvdb_id: 100,
     title: 'Test Show',
     year: 2023,
@@ -112,7 +114,12 @@ describe('RulesService.evaluate', () => {
       },
     ]);
 
-    const { results, summary } = service.evaluate(items, rules, 'test-eval-id');
+    const { results, summary } = service.evaluate(
+      items,
+      rules,
+      'test-eval-id',
+      true,
+    );
     expect(results[0].resolved_action).toBe('keep');
     expect(results[0].matched_rules).toEqual(['Protect permanent']);
     expect(summary.items_matched).toBe(1);
@@ -136,7 +143,7 @@ describe('RulesService.evaluate', () => {
       },
     ]);
 
-    const { results } = service.evaluate(items, rules, 'test-eval-id');
+    const { results } = service.evaluate(items, rules, 'test-eval-id', true);
     expect(results[0].resolved_action).toBeNull();
     expect(results[0].matched_rules).toEqual([]);
   });
@@ -162,7 +169,7 @@ describe('RulesService.evaluate', () => {
       },
     ]);
 
-    const { results } = service.evaluate(items, rules, 'test-eval-id');
+    const { results } = service.evaluate(items, rules, 'test-eval-id', true);
     expect(results[0].resolved_action).toBeNull();
   });
 
@@ -215,7 +222,7 @@ describe('RulesService.evaluate', () => {
       },
     ]);
 
-    const { results } = service.evaluate(items, rules, 'test-eval-id');
+    const { results } = service.evaluate(items, rules, 'test-eval-id', true);
     expect(results[0].resolved_action).toBe('keep');
     expect(results[0].matched_rules).toContain('Delete watched');
     expect(results[0].matched_rules).toContain('Keep permanent');
@@ -268,7 +275,7 @@ describe('RulesService.evaluate', () => {
       },
     ]);
 
-    const { results } = service.evaluate(items, rules, 'test-eval-id');
+    const { results } = service.evaluate(items, rules, 'test-eval-id', true);
     expect(results[0].resolved_action).toBe('unmonitor');
   });
 
@@ -293,7 +300,12 @@ describe('RulesService.evaluate', () => {
       },
     ]);
 
-    const { results, summary } = service.evaluate(items, rules, 'test-eval-id');
+    const { results, summary } = service.evaluate(
+      items,
+      rules,
+      'test-eval-id',
+      true,
+    );
     expect(results[0].resolved_action).toBeNull();
     expect(summary.rules_skipped_missing_data).toBe(1);
   });
@@ -358,7 +370,7 @@ describe('RulesService.evaluate', () => {
       },
     ]);
 
-    const { results } = service.evaluate(items, rules, 'test-eval-id');
+    const { results } = service.evaluate(items, rules, 'test-eval-id', true);
     expect(results[0].resolved_action).toBe('delete');
   });
 
@@ -411,7 +423,7 @@ describe('RulesService.evaluate', () => {
       },
     ]);
 
-    const { results } = service.evaluate(items, rules, 'test-eval-id');
+    const { results } = service.evaluate(items, rules, 'test-eval-id', true);
     expect(results[0].resolved_action).toBe('delete');
   });
 
@@ -445,7 +457,7 @@ describe('RulesService.evaluate', () => {
       },
     ]);
 
-    const { results } = service.evaluate(items, rules, 'test-eval-id');
+    const { results } = service.evaluate(items, rules, 'test-eval-id', true);
     expect(results[0].resolved_action).toBe('delete');
     expect(results[0].type).toBe('season');
   });
@@ -475,7 +487,12 @@ describe('RulesService.evaluate', () => {
       },
     ]);
 
-    const { results, summary } = service.evaluate(items, rules, 'test-eval-id');
+    const { results, summary } = service.evaluate(
+      items,
+      rules,
+      'test-eval-id',
+      true,
+    );
     expect(summary.items_evaluated).toBe(3);
     expect(summary.items_matched).toBe(2);
     expect(results[0].resolved_action).toBe('delete');
@@ -514,7 +531,7 @@ describe('RulesService.evaluate', () => {
       },
     ]);
 
-    const { results } = service.evaluate(items, rules, 'test-eval-id');
+    const { results } = service.evaluate(items, rules, 'test-eval-id', true);
     expect(results[0].resolved_action).toBe('delete');
   });
 
@@ -562,7 +579,7 @@ describe('RulesService.evaluate', () => {
       },
     ]);
 
-    const { summary } = service.evaluate(items, rules, 'test-eval-id');
+    const { summary } = service.evaluate(items, rules, 'test-eval-id', true);
     expect(summary.items_evaluated).toBe(3);
     // Movie 1: skipped (no jellyfin) for "Delete watched", no match for "Keep permanent" → null
     // Movie 2: matches "Delete watched" → delete
@@ -591,7 +608,7 @@ describe('RulesService.evaluate', () => {
       },
     ]);
 
-    const { results } = service.evaluate(items, rules, 'test-eval-id');
+    const { results } = service.evaluate(items, rules, 'test-eval-id', true);
     for (const result of results) {
       expect(result.dry_run).toBe(true);
     }

--- a/src/rules/rules.service.ts
+++ b/src/rules/rules.service.ts
@@ -30,6 +30,7 @@ export class RulesService {
     items: UnifiedMedia[],
     rules: RoombarrConfig['rules'],
     evaluationId: string,
+    dryRun: boolean,
   ): { results: EvaluationItemResult[]; summary: EvaluationSummary } {
     const results: EvaluationItemResult[] = [];
     let skippedCount = 0;
@@ -82,7 +83,7 @@ export class RulesService {
               matchedRules: matchedRuleNames,
               reasoning: reasoningCache.get(winningRule.rule_name) ?? '',
               evaluationId,
-              dryRun: true, // v1 is always dry-run
+              dryRun,
             });
           }
         }
@@ -94,7 +95,7 @@ export class RulesService {
         external_id: externalId,
         matched_rules: matchedRuleNames,
         resolved_action: resolvedAction,
-        dry_run: true,
+        dry_run: dryRun,
       });
     }
 

--- a/src/rules/rules.service.ts
+++ b/src/rules/rules.service.ts
@@ -8,7 +8,7 @@ import type {
   RoombarrConfig,
 } from '../config/config.schema.js';
 import { getServiceFromField } from '../config/field-registry.js';
-import type { UnifiedMedia } from '../shared/types.js';
+import { buildInternalId, type UnifiedMedia } from '../shared/types.js';
 import { resolveField } from './field-resolver.js';
 import { operators } from './operators.js';
 import {
@@ -92,6 +92,7 @@ export class RulesService {
       results.push({
         title: item.title,
         type: item.type,
+        internal_id: buildInternalId(item),
         external_id: externalId,
         matched_rules: matchedRuleNames,
         resolved_action: resolvedAction,

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -5,13 +5,19 @@ import type {
 } from '../config/config.schema.js';
 export type { Action, ConditionGroup, RuleConfig };
 
+export type ExecutionStatus = 'success' | 'failed' | 'skipped';
+
 export interface EvaluationItemResult {
   title: string;
   type: 'movie' | 'season';
   external_id: number;
   matched_rules: string[];
   resolved_action: Action | null;
-  dry_run: true;
+  dry_run: boolean;
+  /** Present only when dry_run is false and an action was attempted. */
+  execution_status?: ExecutionStatus;
+  /** Error message if execution_status is 'failed'. */
+  execution_error?: string;
 }
 
 export interface EvaluationSummary {
@@ -19,6 +25,9 @@ export interface EvaluationSummary {
   items_matched: number;
   actions: Record<Action, number>;
   rules_skipped_missing_data: number;
+  /** Present only when dry_run is false. */
+  actions_executed?: Record<Action, number>;
+  actions_failed?: number;
 }
 
 export interface RuleMatch {

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -10,6 +10,8 @@ export type ExecutionStatus = 'success' | 'failed' | 'skipped';
 export interface EvaluationItemResult {
   title: string;
   type: 'movie' | 'season';
+  /** Composite key unique per item (e.g. "movie:42", "season:10:1"). */
+  internal_id: string;
   external_id: number;
   matched_rules: string[];
   resolved_action: Action | null;

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -16,9 +16,13 @@ export interface EvaluationItemResult {
   matched_rules: string[];
   resolved_action: Action | null;
   dry_run: boolean;
-  /** Present only when dry_run is false and an action was attempted. */
+  /**
+   * Present in both dry-run and live mode. Set to 'skipped' for dry-run items
+   * and non-actionable items in live mode. Set to 'success' or 'failed' after
+   * a live execution attempt. See {@link ExecutionStatus} for possible values.
+   */
   execution_status?: ExecutionStatus;
-  /** Error message if execution_status is 'failed'. */
+  /** Error message populated only when execution_status is 'failed'. */
   execution_error?: string;
 }
 

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -5,7 +5,7 @@ import type {
 } from '../config/config.schema.js';
 export type { Action, ConditionGroup, RuleConfig };
 
-export type ExecutionStatus = 'success' | 'failed' | 'skipped';
+export type ExecutionStatus = 'success' | 'failed' | 'skipped' | 'not_found';
 
 export interface EvaluationItemResult {
   title: string;

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -19,7 +19,8 @@ export interface EvaluationItemResult {
   /**
    * Present in both dry-run and live mode. Set to 'skipped' for dry-run items
    * and non-actionable items in live mode. Set to 'success' or 'failed' after
-   * a live execution attempt. See {@link ExecutionStatus} for possible values.
+   * a live execution attempt. A 404 response is treated as a desired end state
+   * and mapped to 'not_found'. See {@link ExecutionStatus} for possible values.
    */
   execution_status?: ExecutionStatus;
   /** Error message populated only when execution_status is 'failed'. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -77,3 +77,12 @@ export interface UnifiedSeason {
 }
 
 export type UnifiedMedia = UnifiedMovie | UnifiedSeason;
+
+/**
+ * Builds a stable, unique key for any unified media item using internal IDs.
+ * Movies key on radarr_id; seasons key on sonarr_series_id + season_number.
+ */
+export function buildInternalId(item: UnifiedMedia): string {
+  if (item.type === 'movie') return `movie:${item.radarr_id}`;
+  return `season:${item.sonarr_series_id}:${item.sonarr.season.season_number}`;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -53,6 +53,7 @@ export interface StateData {
 
 export interface UnifiedMovie {
   type: 'movie';
+  radarr_id: number;
   tmdb_id: number;
   imdb_id: string | null;
   title: string;
@@ -65,6 +66,7 @@ export interface UnifiedMovie {
 
 export interface UnifiedSeason {
   type: 'season';
+  sonarr_series_id: number;
   tvdb_id: number;
   title: string;
   year: number;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,6 +6,7 @@
 export interface RadarrData {
   added: string;
   size_on_disk: number;
+  has_file: boolean;
   monitored: boolean;
   tags: string[];
   genres: string[];
@@ -29,6 +30,7 @@ export interface SonarrData {
     monitored: boolean;
     episode_count: number;
     episode_file_count: number;
+    has_file: boolean;
     size_on_disk: number;
   };
 }

--- a/src/snapshot/snapshot.service.test.ts
+++ b/src/snapshot/snapshot.service.test.ts
@@ -20,6 +20,7 @@ function makeMovie(overrides: Record<string, any> = {}): UnifiedMovie {
     radarr: {
       added: '2024-01-01T00:00:00Z',
       size_on_disk: 5_000_000_000,
+      has_file: true,
       monitored: true,
       tags: [],
       genres: ['Action'],

--- a/src/snapshot/snapshot.service.test.ts
+++ b/src/snapshot/snapshot.service.test.ts
@@ -10,6 +10,7 @@ import { SnapshotService } from './snapshot.service.js';
 function makeMovie(overrides: Record<string, any> = {}): UnifiedMovie {
   return {
     type: 'movie',
+    radarr_id: 101,
     tmdb_id: 1,
     imdb_id: 'tt0000001',
     title: 'Test Movie',

--- a/src/snapshot/snapshot.service.test.ts
+++ b/src/snapshot/snapshot.service.test.ts
@@ -7,10 +7,12 @@ import { DatabaseService } from '../database/database.service.js';
 import type { UnifiedMovie } from '../shared/types.js';
 import { SnapshotService } from './snapshot.service.js';
 
+let nextRadarrId = 101;
+
 function makeMovie(overrides: Record<string, any> = {}): UnifiedMovie {
   return {
     type: 'movie',
-    radarr_id: 101,
+    radarr_id: nextRadarrId++,
     tmdb_id: 1,
     imdb_id: 'tt0000001',
     title: 'Test Movie',

--- a/src/snapshot/state.service.test.ts
+++ b/src/snapshot/state.service.test.ts
@@ -19,6 +19,7 @@ function makeMovie(overrides: Record<string, any> = {}): UnifiedMovie {
     radarr: {
       added: '2024-01-01T00:00:00Z',
       size_on_disk: 5_000_000_000,
+      has_file: true,
       monitored: true,
       tags: [],
       genres: ['Action'],
@@ -209,6 +210,7 @@ describe('StateService', () => {
           monitored: true,
           episode_count: 10,
           episode_file_count: 10,
+          has_file: true,
           size_on_disk: 10_000_000_000,
         },
       },

--- a/src/snapshot/state.service.test.ts
+++ b/src/snapshot/state.service.test.ts
@@ -11,6 +11,7 @@ import { StateService } from './state.service.js';
 function makeMovie(overrides: Record<string, any> = {}): UnifiedMovie {
   return {
     type: 'movie',
+    radarr_id: 101,
     tmdb_id: 1,
     imdb_id: 'tt0000001',
     title: 'Test Movie',
@@ -193,6 +194,7 @@ describe('StateService', () => {
   test('returns seasons unchanged when no registry fields target sonarr', async () => {
     const season: UnifiedSeason = {
       type: 'season',
+      sonarr_series_id: 201,
       tvdb_id: 100,
       title: 'Test Show - S01',
       year: 2024,

--- a/src/sonarr/sonarr.client.ts
+++ b/src/sonarr/sonarr.client.ts
@@ -1,7 +1,11 @@
 import { HttpService } from '@nestjs/axios';
 import { Injectable, Logger } from '@nestjs/common';
 import { firstValueFrom } from 'rxjs';
-import type { SonarrSeries, SonarrTag } from './sonarr.types.js';
+import type {
+  SonarrEpisodeFile,
+  SonarrSeries,
+  SonarrTag,
+} from './sonarr.types.js';
 
 @Injectable()
 export class SonarrClient {
@@ -16,6 +20,36 @@ export class SonarrClient {
     );
     this.logger.debug(`Fetched ${data.length} series`);
     return data;
+  }
+
+  async fetchSeriesById(seriesId: number): Promise<SonarrSeries> {
+    this.logger.debug(`Fetching series ${seriesId} from Sonarr`);
+    const { data } = await firstValueFrom(
+      this.http.get<SonarrSeries>(`/api/v3/series/${seriesId}`),
+    );
+    return data;
+  }
+
+  async updateSeries(seriesId: number, body: SonarrSeries): Promise<void> {
+    this.logger.debug(`Updating series ${seriesId}`);
+    await firstValueFrom(this.http.put(`/api/v3/series/${seriesId}`, body));
+  }
+
+  async fetchEpisodeFiles(seriesId: number): Promise<SonarrEpisodeFile[]> {
+    this.logger.debug(`Fetching episode files for series ${seriesId}`);
+    const { data } = await firstValueFrom(
+      this.http.get<SonarrEpisodeFile[]>('/api/v3/episodefile', {
+        params: { seriesId },
+      }),
+    );
+    return data;
+  }
+
+  async deleteEpisodeFile(episodeFileId: number): Promise<void> {
+    this.logger.debug(`Deleting episode file ${episodeFileId}`);
+    await firstValueFrom(
+      this.http.delete(`/api/v3/episodefile/${episodeFileId}`),
+    );
   }
 
   async fetchTags(): Promise<SonarrTag[]> {

--- a/src/sonarr/sonarr.mapper.test.ts
+++ b/src/sonarr/sonarr.mapper.test.ts
@@ -92,6 +92,7 @@ describe('mapSeason', () => {
         monitored: true,
         episode_count: 7,
         episode_file_count: 7,
+        has_file: true,
         size_on_disk: 14_000_000_000,
       },
     });
@@ -107,6 +108,7 @@ describe('mapSeason', () => {
       monitored: false,
       episode_count: 0,
       episode_file_count: 0,
+      has_file: false,
       size_on_disk: 0,
     });
   });

--- a/src/sonarr/sonarr.mapper.ts
+++ b/src/sonarr/sonarr.mapper.ts
@@ -44,6 +44,7 @@ export function mapSeason(
       monitored: season.monitored,
       episode_count: stats?.episodeCount ?? 0,
       episode_file_count: stats?.episodeFileCount ?? 0,
+      has_file: (stats?.episodeFileCount ?? 0) > 0,
       size_on_disk: stats?.sizeOnDisk ?? 0,
     },
   };

--- a/src/sonarr/sonarr.module.ts
+++ b/src/sonarr/sonarr.module.ts
@@ -19,6 +19,6 @@ import { SonarrService } from './sonarr.service.js';
     }),
   ],
   providers: [SonarrClient, SonarrService],
-  exports: [SonarrService],
+  exports: [SonarrClient, SonarrService],
 })
 export class SonarrModule {}

--- a/src/sonarr/sonarr.service.ts
+++ b/src/sonarr/sonarr.service.ts
@@ -33,6 +33,7 @@ export class SonarrService {
 
         seasons.push({
           type: 'season',
+          sonarr_series_id: s.id,
           tvdb_id: s.tvdbId,
           title: `${s.title} - S${String(season.seasonNumber).padStart(2, '0')}`,
           year: s.year,

--- a/src/sonarr/sonarr.types.ts
+++ b/src/sonarr/sonarr.types.ts
@@ -36,3 +36,11 @@ export interface SonarrTag {
   id: number;
   label: string;
 }
+
+export interface SonarrEpisodeFile {
+  id: number;
+  seriesId: number;
+  seasonNumber: number;
+  path: string;
+  size: number;
+}


### PR DESCRIPTION
## Summary

- Add `dry_run` config option (default: `true`) so users can opt into live execution while preserving the ability to preview actions first
- Implement `ActionExecutorService` that performs delete/unmonitor operations against Radarr and Sonarr APIs when `dry_run: false`
- Wire the executor into the evaluation pipeline as Step 5: hydrate → snapshot → enrich → evaluate → **execute** → respond
- Add `radarr.has_file` and `sonarr.season.has_file` fields for checking media file presence in rule conditions

### What's supported

| Action | Radarr (movies) | Sonarr (seasons) |
|--------|-----------------|------------------|
| **Delete** | `DELETE /api/v3/movie/{id}?deleteFiles=true` | Fetches episode files per season, deletes each via `DELETE /api/v3/episodefile/{id}` |
| **Unmonitor** | Re-fetches movie, sets `monitored: false`, PUTs full body | Re-fetches series, flips season's `monitored: false`, PUTs full body |
| **Keep** | No-op (protective action) | No-op (protective action) |

### New fields

| Field | Type | Description | Notes |
|-------|------|-------------|-------|
| `radarr.has_file` | boolean | Whether a file exists on disk | First-class Radarr API field |
| `sonarr.season.has_file` | boolean | Whether the season has any episode files | Derived from episode_file_count > 0 |

### Design decisions

- **Sequential execution** — mutations are dangerous; no parallelism in v1
- **Continue on failure** — if item 4/10 fails, items 5-10 still execute
- **404 = success** — if Radarr/Sonarr returns 404 on delete, desired state is achieved
- **Re-fetch before PUT** — avoids metadata corruption from partial unmonitor bodies
- **Lazy episode file fetching** — only fetched during execution, not hydration

## Testing

- 262 tests pass (12 for ActionExecutorService, 3 for has_file coverage)
- Covers: all 4 action types, dry-run no-op, 404-as-success, continue-after-failure, item-not-found, execution summary counts, config validation for has_file fields, field resolution for has_file
- TypeScript strict mode clean, Biome lint clean

## Post-Deploy Monitoring & Validation

- **What to monitor**: Radarr/Sonarr API call logs — look for unexpected `DELETE` or `PUT` calls when `dry_run: true`
- **Expected healthy behavior**: With `dry_run: true` (default), zero mutation API calls. With `dry_run: false`, delete/unmonitor calls matching evaluation results
- **Failure signal / rollback trigger**: Any mutation call when `dry_run: true` → immediate rollback
- **Validation window & owner**: First live run with `dry_run: false` on a test library

## Plan

See `docs/plans/2026-03-04-feat-enable-live-action-execution-plan.md` for full design and acceptance criteria.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global dry-run mode (default) with an option to enable live execution; runs now include dry_run, per-item execution_status, and aggregated execution summary.
  * Items include service IDs and has_file indicators to improve detection and execution (delete/unmonitor) accuracy.
* **Documentation**
  * Config docs updated with dry_run guidance, examples, and audit log behavior.
* **Chores**
  * Docker configuration switched to build locally instead of pulling a prebuilt image.
* **Tests**
  * Expanded test coverage for execution paths, dry-run vs live behavior, and file-presence handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->