### PR TITLE
chore: remove release-as override and delete v1.0.0 tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "release-as": "0.1.0",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true
     }


### PR DESCRIPTION
## Summary

- Removes the one-shot `release-as: "0.1.0"` override from `release-please-config.json` so future releases follow conventional commits normally
- Deletes the stale `v1.0.0` git tag from the remote (no GitHub release or Docker images existed for it)

## Context

PR #12 completed the version reset to `0.1.0`. This PR cleans up the leftover configuration and tag artifacts from that process.

## Verification

After merge:
- `release-please-config.json` has no `release-as` key
- `git tag -l` on remote shows only `v0.1.0`
- `gh release list` shows only `v0.1.0`
- No new release-please PR opens (this is a `chore:` commit)