### PR TITLE
fix: prevent re-requested media from immediate deletion

### DIFF
--- a/src/config/__snapshots__/field-registry.test.ts.snap
+++ b/src/config/__snapshots__/field-registry.test.ts.snap
@@ -21,6 +21,7 @@ exports[`fieldRegistry radarr registry fields match snapshot 1`] = `
   "radarr.status",
   "radarr.tags",
   "radarr.year",
+  "snapshot.first_seen_at",
   "state.days_off_import_list",
   "state.ever_on_import_list",
 ]
@@ -35,6 +36,7 @@ exports[`fieldRegistry sonarr registry fields match snapshot 1`] = `
   "jellyseerr.request_status",
   "jellyseerr.requested_at",
   "jellyseerr.requested_by",
+  "snapshot.first_seen_at",
   "sonarr.genres",
   "sonarr.path",
   "sonarr.season.episode_count",

--- a/src/config/field-registry.test.ts
+++ b/src/config/field-registry.test.ts
@@ -60,6 +60,14 @@ describe('fieldRegistry', () => {
     }
   });
 
+  test('snapshot.first_seen_at field is registered on both targets', () => {
+    const radarrDef = fieldRegistry.radarr['snapshot.first_seen_at'];
+    const sonarrDef = fieldRegistry.sonarr['snapshot.first_seen_at'];
+    expect(radarrDef.type).toBe('date');
+    expect(radarrDef.service).toBe('snapshot');
+    expect(sonarrDef).toEqual(radarrDef);
+  });
+
   test('enrichment fields are identical across both targets', () => {
     const enrichmentKeys = [
       'jellyfin.watched_by',

--- a/src/config/field-registry.ts
+++ b/src/config/field-registry.ts
@@ -14,6 +14,7 @@ export type ServiceName =
   | 'sonarr'
   | 'jellyfin'
   | 'jellyseerr'
+  | 'snapshot'
   | 'state';
 
 export interface FieldDefinition {
@@ -217,6 +218,15 @@ export const stateFields: Record<string, FieldDefinition> = {
   },
 };
 
+export const snapshotFields: Record<string, FieldDefinition> = {
+  'snapshot.first_seen_at': {
+    type: 'date',
+    service: 'snapshot',
+    description:
+      'When roombarr first observed this item in its current lifecycle. Resets if media is removed and re-added.',
+  },
+};
+
 const enrichmentFields: Record<string, FieldDefinition> = {
   ...jellyfinFields,
   ...jellyseerrFields,
@@ -226,8 +236,18 @@ export const fieldRegistry: Record<
   'radarr' | 'sonarr',
   Record<string, FieldDefinition>
 > = {
-  radarr: { ...radarrFields, ...enrichmentFields, ...stateFields },
-  sonarr: { ...sonarrFields, ...enrichmentFields, ...stateFields },
+  radarr: {
+    ...radarrFields,
+    ...enrichmentFields,
+    ...stateFields,
+    ...snapshotFields,
+  },
+  sonarr: {
+    ...sonarrFields,
+    ...enrichmentFields,
+    ...stateFields,
+    ...snapshotFields,
+  },
 };
 
 export const operatorDefinitions: Record<string, OperatorDefinition> = {

--- a/src/jellyseerr/jellyseerr.service.test.ts
+++ b/src/jellyseerr/jellyseerr.service.test.ts
@@ -94,4 +94,70 @@ describe('JellyseerrService', () => {
     expect(result.byTmdbId.has(400)).toBe(true);
     expect(result.byTvdbId.has(400)).toBe(false);
   });
+
+  test('uses the most recent request when multiple exist for same movie', async () => {
+    const oldRequest = makeJellyseerrRequest({
+      id: 1,
+      type: 'movie',
+      createdAt: '2024-01-01T00:00:00Z',
+      media: { id: 1, tmdbId: 603, mediaType: 'movie', status: 5 },
+    });
+    const newRequest = makeJellyseerrRequest({
+      id: 2,
+      type: 'movie',
+      createdAt: '2025-06-01T00:00:00Z',
+      media: { id: 2, tmdbId: 603, mediaType: 'movie', status: 5 },
+    });
+    client.fetchAllRequests = mock(() =>
+      Promise.resolve([oldRequest, newRequest]),
+    );
+
+    const result = await service.fetchRequestData();
+
+    expect(result.byTmdbId.get(603)!.requested_at).toBe('2025-06-01T00:00:00Z');
+  });
+
+  test('uses latest request even when older request appears later in API response', async () => {
+    const newRequest = makeJellyseerrRequest({
+      id: 2,
+      type: 'movie',
+      createdAt: '2025-06-01T00:00:00Z',
+      media: { id: 2, tmdbId: 603, mediaType: 'movie', status: 5 },
+    });
+    const oldRequest = makeJellyseerrRequest({
+      id: 1,
+      type: 'movie',
+      createdAt: '2024-01-01T00:00:00Z',
+      media: { id: 1, tmdbId: 603, mediaType: 'movie', status: 5 },
+    });
+    client.fetchAllRequests = mock(() =>
+      Promise.resolve([newRequest, oldRequest]),
+    );
+
+    const result = await service.fetchRequestData();
+
+    expect(result.byTmdbId.get(603)!.requested_at).toBe('2025-06-01T00:00:00Z');
+  });
+
+  test('uses the most recent request when multiple exist for same TV show', async () => {
+    const newRequest = makeJellyseerrRequest({
+      id: 2,
+      type: 'tv',
+      createdAt: '2025-06-01T00:00:00Z',
+      media: { id: 2, tmdbId: 200, tvdbId: 300, mediaType: 'tv', status: 5 },
+    });
+    const oldRequest = makeJellyseerrRequest({
+      id: 1,
+      type: 'tv',
+      createdAt: '2024-01-01T00:00:00Z',
+      media: { id: 1, tmdbId: 200, tvdbId: 300, mediaType: 'tv', status: 5 },
+    });
+    client.fetchAllRequests = mock(() =>
+      Promise.resolve([newRequest, oldRequest]),
+    );
+
+    const result = await service.fetchRequestData();
+
+    expect(result.byTvdbId.get(300)!.requested_at).toBe('2025-06-01T00:00:00Z');
+  });
 });

--- a/src/jellyseerr/jellyseerr.service.ts
+++ b/src/jellyseerr/jellyseerr.service.ts
@@ -29,9 +29,15 @@ export class JellyseerrService {
       const mapped = mapRequest(request);
 
       if (request.type === 'movie') {
-        byTmdbId.set(request.media.tmdbId, mapped);
+        const existing = byTmdbId.get(request.media.tmdbId);
+        if (!existing || request.createdAt > existing.requested_at) {
+          byTmdbId.set(request.media.tmdbId, mapped);
+        }
       } else if (request.type === 'tv' && request.media.tvdbId !== undefined) {
-        byTvdbId.set(request.media.tvdbId, mapped);
+        const existing = byTvdbId.get(request.media.tvdbId);
+        if (!existing || request.createdAt > existing.requested_at) {
+          byTvdbId.set(request.media.tvdbId, mapped);
+        }
       }
     }
 

--- a/src/radarr/radarr.service.ts
+++ b/src/radarr/radarr.service.ts
@@ -39,6 +39,7 @@ export class RadarrService {
       jellyfin: null,
       jellyseerr: null,
       state: null,
+      snapshot: null,
     }));
 
     this.logger.log(`Fetched and mapped ${unified.length} movies`);

--- a/src/rules/rules.service.test.ts
+++ b/src/rules/rules.service.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import type { AuditService } from '../audit/audit.service';
 import type { RuleConfig } from '../config/config.schema';
 import type { UnifiedMedia } from '../shared/types';
-import { makeMovie, makeSeason } from '../test/index';
+import { makeMovie, makeRule, makeSeason } from '../test/index';
 import { RulesService } from './rules.service';
 
 const mockAuditService = {
@@ -547,5 +547,29 @@ describe('RulesService.evaluate', () => {
     for (const result of results) {
       expect(result.dry_run).toBe(false);
     }
+  });
+
+  test('does not skip rules that reference snapshot fields', () => {
+    const rule = makeRule({
+      target: 'radarr',
+      conditions: {
+        operator: 'AND',
+        children: [
+          {
+            field: 'snapshot.first_seen_at',
+            operator: 'older_than',
+            value: '7d',
+          },
+        ],
+      },
+    });
+
+    const movie = makeMovie({
+      snapshot: { first_seen_at: '2020-01-01T00:00:00Z' },
+    });
+
+    const { results } = service.evaluate([movie], [rule], 'test-run', true);
+
+    expect(results[0].matched_rules).toContain(rule.name);
   });
 });

--- a/src/rules/rules.service.ts
+++ b/src/rules/rules.service.ts
@@ -128,7 +128,10 @@ export class RulesService {
    * should never cause a rule to be skipped. State is computed locally
    * from SQLite, not fetched from an external API.
    */
-  private static readonly ALWAYS_PRESENT_SERVICES = new Set(['state']);
+  private static readonly ALWAYS_PRESENT_SERVICES = new Set([
+    'state',
+    'snapshot',
+  ]);
 
   /**
    * Check if a rule references service data that's missing on the item.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -53,6 +53,10 @@ export interface StateData {
   ever_on_import_list: boolean;
 }
 
+export interface SnapshotData {
+  first_seen_at: string;
+}
+
 export interface UnifiedMovie {
   type: 'movie';
   radarr_id: number;
@@ -64,6 +68,7 @@ export interface UnifiedMovie {
   jellyfin: JellyfinData | null;
   jellyseerr: JellyseerrData | null;
   state: StateData | null;
+  snapshot: SnapshotData | null;
 }
 
 export interface UnifiedSeason {
@@ -76,6 +81,7 @@ export interface UnifiedSeason {
   jellyfin: JellyfinData | null;
   jellyseerr: JellyseerrData | null;
   state: StateData | null;
+  snapshot: SnapshotData | null;
 }
 
 export type UnifiedMedia = UnifiedMovie | UnifiedSeason;

--- a/src/snapshot/snapshot-state.integration.test.ts
+++ b/src/snapshot/snapshot-state.integration.test.ts
@@ -197,17 +197,15 @@ describe('Snapshot → State integration', () => {
     expect(orphanCheck.count).toBe(0);
 
     // Step 3: Item reappears (re-requested)
+    const preReinsert = new Date();
     await snapshotService.snapshot([movie], services);
 
     // Step 4: Enrich — should get a fresh first_seen_at
     const [enriched] = stateService.enrich([movie]);
 
     expect(enriched.snapshot).not.toBeNull();
-    // first_seen_at should be very recent (within last few seconds)
     const firstSeenAt = new Date(enriched.snapshot!.first_seen_at);
-    const now = new Date();
-    const diffMs = now.getTime() - firstSeenAt.getTime();
-    expect(diffMs).toBeLessThan(5000); // Less than 5 seconds ago
+    expect(firstSeenAt.getTime()).toBeGreaterThanOrEqual(preReinsert.getTime());
   });
 
   test('late-arriving item gets state on its first cycle when other snapshots exist', async () => {

--- a/src/snapshot/snapshot-state.integration.test.ts
+++ b/src/snapshot/snapshot-state.integration.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
-import { and, eq, sql } from 'drizzle-orm';
-import { fieldChanges } from '../database/schema';
+import { and, count, eq, sql } from 'drizzle-orm';
+import { fieldChanges, mediaItems } from '../database/schema';
 import type { UnifiedMedia, UnifiedMovie } from '../shared/types';
 import { makeMovie, useTestDatabase } from '../test/index';
 import { SnapshotService } from './snapshot.service';
@@ -175,6 +175,39 @@ describe('Snapshot → State integration', () => {
     // B: just went on
     expect(stateB2.ever_on_import_list).toBe(true);
     expect(stateB2.days_off_import_list).toBeNull();
+  });
+
+  test('re-requested media gets fresh first_seen_at after orphan cleanup', async () => {
+    const movie = makeMovie({ tmdb_id: 42, title: 'Re-Requested Movie' });
+
+    // Step 1: Initial snapshot
+    await snapshotService.snapshot([movie], services);
+
+    // Step 2: Item disappears — simulate deletion from Radarr
+    // 8 evaluations with no items (grace period is 7)
+    for (let i = 0; i < 8; i++) {
+      await snapshotService.snapshot([], services);
+    }
+
+    // Verify orphan was cleaned up
+    const [orphanCheck] = db.drizzle
+      .select({ count: count() })
+      .from(mediaItems)
+      .all();
+    expect(orphanCheck.count).toBe(0);
+
+    // Step 3: Item reappears (re-requested)
+    await snapshotService.snapshot([movie], services);
+
+    // Step 4: Enrich — should get a fresh first_seen_at
+    const [enriched] = stateService.enrich([movie]);
+
+    expect(enriched.snapshot).not.toBeNull();
+    // first_seen_at should be very recent (within last few seconds)
+    const firstSeenAt = new Date(enriched.snapshot!.first_seen_at);
+    const now = new Date();
+    const diffMs = now.getTime() - firstSeenAt.getTime();
+    expect(diffMs).toBeLessThan(5000); // Less than 5 seconds ago
   });
 
   test('late-arriving item gets state on its first cycle when other snapshots exist', async () => {

--- a/src/snapshot/state.service.test.ts
+++ b/src/snapshot/state.service.test.ts
@@ -144,6 +144,31 @@ describe('StateService', () => {
     expect(enrichedSeason.state).toBeNull();
   });
 
+  test('populates snapshot.first_seen_at from media_items', async () => {
+    const movie = makeMovie({ tmdb_id: 42, title: 'My Movie' });
+
+    // Create initial snapshot so item exists in DB
+    await snapshotService.snapshot([movie], new Set(['radarr']));
+
+    // Enrich should populate snapshot
+    const [enriched] = stateService.enrich([movie]);
+
+    expect(enriched.snapshot).not.toBeNull();
+    expect(enriched.snapshot!.first_seen_at).toBeTruthy();
+    // Should be a valid ISO timestamp
+    expect(new Date(enriched.snapshot!.first_seen_at).toISOString()).toBe(
+      enriched.snapshot!.first_seen_at,
+    );
+  });
+
+  test('returns null snapshot for items without a snapshot row', () => {
+    const movie = makeMovie({ tmdb_id: 999, title: 'Unknown Movie' });
+
+    const [enriched] = stateService.enrich([movie]);
+
+    expect(enriched.snapshot).toBeNull();
+  });
+
   test('batch query handles multiple items efficiently', async () => {
     const movie1 = makeMovie({
       tmdb_id: 1,

--- a/src/snapshot/state.service.ts
+++ b/src/snapshot/state.service.ts
@@ -147,7 +147,6 @@ export class StateService {
     const mediaId = compositeKey.split(':')[1];
     const snapshot = db
       .select({
-        mediaId: mediaItems.mediaId,
         firstSeenAt: mediaItems.firstSeenAt,
       })
       .from(mediaItems)

--- a/src/snapshot/state.service.ts
+++ b/src/snapshot/state.service.ts
@@ -87,7 +87,7 @@ export class StateService {
       const mediaId = this.getMediaId(item);
       const compositeKey = `${item.type}:${mediaId}`;
 
-      const state = this.computeState(
+      const { state, firstSeenAt } = this.computeState(
         item,
         target,
         compositeKey,
@@ -95,7 +95,9 @@ export class StateService {
         changeIndex,
       );
 
-      return { ...item, state };
+      const snapshot = firstSeenAt ? { first_seen_at: firstSeenAt } : null;
+
+      return { ...item, state, snapshot };
     });
   }
 
@@ -137,21 +139,24 @@ export class StateService {
     compositeKey: string,
     entries: Array<[string, StateFieldPattern]>,
     changeIndex: Map<string, Map<string, FieldChangeRow[]>>,
-  ): StateData | null {
+  ): { state: StateData | null; firstSeenAt: string | null } {
     const db = this.getDb();
 
     // Check if this item has been snapshotted before
     const mediaType = item.type === 'movie' ? 'movie' : 'season';
     const mediaId = compositeKey.split(':')[1];
     const snapshot = db
-      .select({ mediaId: mediaItems.mediaId })
+      .select({
+        mediaId: mediaItems.mediaId,
+        firstSeenAt: mediaItems.firstSeenAt,
+      })
       .from(mediaItems)
       .where(
         sql`${mediaItems.mediaType} = ${mediaType} AND ${mediaItems.mediaId} = ${mediaId}`,
       )
       .get();
 
-    if (!snapshot) return null;
+    if (!snapshot) return { state: null, firstSeenAt: null };
 
     const itemChanges = changeIndex.get(compositeKey);
     const result: Record<string, unknown> = {};
@@ -180,10 +185,13 @@ export class StateService {
     }
 
     return {
-      days_off_import_list:
-        (result['state.days_off_import_list'] as number | null) ?? null,
-      ever_on_import_list:
-        (result['state.ever_on_import_list'] as boolean) ?? false,
+      state: {
+        days_off_import_list:
+          (result['state.days_off_import_list'] as number | null) ?? null,
+        ever_on_import_list:
+          (result['state.ever_on_import_list'] as boolean) ?? false,
+      },
+      firstSeenAt: snapshot.firstSeenAt,
     };
   }
 

--- a/src/sonarr/sonarr.service.ts
+++ b/src/sonarr/sonarr.service.ts
@@ -41,6 +41,7 @@ export class SonarrService {
           jellyfin: null,
           jellyseerr: null,
           state: null,
+          snapshot: null,
         });
       }
     }

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -73,6 +73,7 @@ export function makeMovie(overrides: MovieOverrides = {}): UnifiedMovie {
     jellyfin: null,
     jellyseerr: null,
     state: null,
+    snapshot: null,
     ...topLevel,
     radarr: { ...defaultRadarr, ...radarrOverrides },
   };
@@ -96,6 +97,7 @@ export function makeSeason(overrides: SeasonOverrides = {}): UnifiedSeason {
     jellyfin: null,
     jellyseerr: null,
     state: null,
+    snapshot: null,
     ...topLevel,
     sonarr: {
       ...defaultSonarr,


### PR DESCRIPTION
## Summary

- **Use most recent Jellyseerr request per media** — When multiple requests exist for the same TMDB/TVDB ID (e.g., original request + re-request after deletion), we now keep the one with the latest `createdAt` instead of blindly overwriting. This fixes the core bug where re-requested media was immediately deleted because the old request's stale date was used.
- **Expose `snapshot.first_seen_at` as a queryable field** — New date field that tracks when roombarr first observed an item in its current lifecycle. Resets when media is orphaned out of the database and re-added, giving users a reliable "clock reset" field for time-based rules.

## Test plan

- [x] Three new tests for Jellyseerr duplicate request handling (movie, reverse order, TV)
- [x] Two new tests for snapshot enrichment (populated from DB, null when no snapshot)
- [x] One new test for rules service (snapshot fields don't cause rule skip)
- [x] One new integration test for full re-request lifecycle (snapshot → orphan cleanup → re-snapshot → fresh first_seen_at)
- [x] All existing tests pass (7 pre-existing failures in HealthController/EvaluationController unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added snapshot tracking to record when media items are first discovered
- Snapshot data now available as a rule condition field for advanced filtering
- Improved duplicate media request handling to use the most recent request timestamp

**Tests**
- Enhanced test coverage for snapshot functionality and related edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->