### PR TITLE
feat(safety): bound evaluation runtime and cap deletes per run

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,4 @@ docs
 .env.*
 .vscode
 .github
+temp

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ todos/
 pnpm-lock.yaml
 
 docs/.astro/
+
+temp/

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -83,6 +83,20 @@ audit:
   retention_days: 90 # 1–3650, default: 90
 ```
 
+## Safety
+
+**Optional.** Bounds on a single evaluation. Both have defaults; you only need this block to change them.
+
+```yaml
+safety:
+  evaluation_timeout: 1h # default: 1h, max: ~24.8 days
+  max_deletes_per_run: 50 # default: 50, null to disable
+```
+
+`evaluation_timeout` is the wall-clock budget for one run. A run still going when it elapses is abandoned and the scheduler is released, so a single hung request can't stop Roombarr from ever running again. The abandoned run stops at its next step boundary and does not execute further actions.
+
+`max_deletes_per_run` refuses a run that resolves more deletes than the limit — nothing is executed and an error is logged. A rule change or an upstream data shift can unprotect a large share of a library at once; refusing the run is recoverable, deleting it is not. Size it above your normal run and revisit it after a rule change: check a `dry_run` first, raise the limit deliberately for a one-off catch-up, then put it back.
+
 ## Rules
 
 Rules are the core of Roombarr. Each rule targets either `radarr` or `sonarr`, defines conditions using a composable AND/OR tree, and specifies an action.
@@ -183,7 +197,7 @@ conditions:
 A rule is skipped for an item when the enrichment data it needs is missing — Roombarr won't act on incomplete information.
 
 - **Missing item data** — If Jellyfin has no data for a specific movie, rules referencing `jellyfin.*` fields are skipped for that movie only.
-- **Unreachable service** — If Jellyfin is down, all items have null Jellyfin data and every rule referencing Jellyfin fields is skipped for that run.
+- **Unreachable service** — If a service a rule depends on cannot be reached, the whole run fails and nothing is executed. A skipped `keep` rule is an unprotected item, so Roombarr will not act on a library it could not fully see.
 
 :::note
 State fields (`state.*`) are exempt from skipping. A null state value means "no history yet" — it's meaningful data, not missing data.

--- a/roombarr.example.yml
+++ b/roombarr.example.yml
@@ -47,6 +47,7 @@ performance:
 #   # Wall-clock budget for one evaluation. If a run is still going when this
 #   # elapses it is abandoned and the scheduler is released, so a single hung
 #   # request cannot stop Roombarr from running again. Default: 1h.
+#   # Maximum ~24.8 days — the underlying timer cannot represent more.
 #   evaluation_timeout: 1h
 #
 #   # Refuse to execute a run that resolves more than this many deletes.

--- a/roombarr.example.yml
+++ b/roombarr.example.yml
@@ -42,6 +42,19 @@ performance:
 # audit:
 #   retention_days: 90           # Default: 90. Min: 1. Max: 3650.
 
+# ── Safety ────────────────────────────────────────────────────
+# safety:
+#   # Wall-clock budget for one evaluation. If a run is still going when this
+#   # elapses it is abandoned and the scheduler is released, so a single hung
+#   # request cannot stop Roombarr from running again. Default: 1h.
+#   evaluation_timeout: 1h
+#
+#   # Refuse to execute a run that resolves more than this many deletes.
+#   # Nothing is deleted and an error is logged, so a rule change or upstream
+#   # data shift that unprotects the library en masse stops for review instead
+#   # of emptying the disk. Set to null to disable. Default: 50.
+#   max_deletes_per_run: 50
+
 # ── Rules ─────────────────────────────────────────────────────
 # Each rule targets either sonarr (TV seasons) or radarr (movies).
 # Conditions are AND/OR trees referencing fields from any configured service.

--- a/src/config/config.schema.ts
+++ b/src/config/config.schema.ts
@@ -71,6 +71,10 @@ export interface RoombarrConfig {
   audit: {
     retention_days: number;
   };
+  safety: {
+    evaluation_timeout: string;
+    max_deletes_per_run: number | null;
+  };
   rules: RuleConfig[];
 }
 
@@ -123,6 +127,47 @@ const auditSchema = z
   })
   .default(AUDIT_DEFAULTS);
 
+const SAFETY_DEFAULTS = {
+  evaluation_timeout: '1h',
+  max_deletes_per_run: 50,
+} as const;
+
+const safetySchema = z
+  .object({
+    /**
+     * Wall-clock budget for a single evaluation. If an evaluation is still
+     * running when this elapses it is abandoned and the scheduler is released,
+     * so one wedged request cannot disable Roombarr indefinitely.
+     */
+    evaluation_timeout: z
+      .string()
+      .min(1)
+      .default(SAFETY_DEFAULTS.evaluation_timeout)
+      .check(ctx => {
+        const ms = parse(ctx.value);
+        if (ms === null || ms <= 0) {
+          ctx.issues.push({
+            code: 'custom',
+            input: ctx.value,
+            message: `Invalid duration "${ctx.value}" for safety.evaluation_timeout. Examples: 30m, 1h, 2h.`,
+          });
+        }
+      }),
+    /**
+     * Upper bound on delete actions a single evaluation may execute. When a
+     * run resolves more deletes than this, nothing is executed — a rule or
+     * upstream data change that unprotects the library en masse should stop
+     * for review rather than empty the disk. `null` disables the check.
+     */
+    max_deletes_per_run: z
+      .number()
+      .int()
+      .min(0)
+      .nullable()
+      .default(SAFETY_DEFAULTS.max_deletes_per_run),
+  })
+  .default(SAFETY_DEFAULTS);
+
 const servicesSchema = z.object({
   sonarr: serviceConfigSchema.optional(),
   radarr: serviceConfigSchema.optional(),
@@ -147,6 +192,7 @@ export const configSchema = z.object({
     }),
   performance: performanceSchema,
   audit: auditSchema,
+  safety: safetySchema,
   rules: z.array(ruleSchema).min(1),
 });
 

--- a/src/config/config.schema.ts
+++ b/src/config/config.schema.ts
@@ -132,6 +132,14 @@ const SAFETY_DEFAULTS = {
   max_deletes_per_run: 50,
 } as const;
 
+/**
+ * Largest delay `setTimeout` can represent. Node and Bun store the delay as a
+ * signed 32-bit integer, so anything larger silently wraps to `1`ms and fires
+ * immediately. Timeouts beyond this are rejected at config time rather than
+ * quietly aborting every evaluation the instant it starts.
+ */
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
 const safetySchema = z
   .object({
     /**
@@ -145,11 +153,21 @@ const safetySchema = z
       .default(SAFETY_DEFAULTS.evaluation_timeout)
       .check(ctx => {
         const ms = parse(ctx.value);
+
         if (ms === null || ms <= 0) {
           ctx.issues.push({
             code: 'custom',
             input: ctx.value,
             message: `Invalid duration "${ctx.value}" for safety.evaluation_timeout. Examples: 30m, 1h, 2h.`,
+          });
+          return;
+        }
+
+        if (!Number.isFinite(ms) || ms > MAX_TIMER_DELAY_MS) {
+          ctx.issues.push({
+            code: 'custom',
+            input: ctx.value,
+            message: `Duration "${ctx.value}" for safety.evaluation_timeout is too large. The maximum supported timeout is ${MAX_TIMER_DELAY_MS}ms (~24.8 days); larger values overflow the underlying timer and would abort every evaluation immediately. Use a shorter duration, e.g. 1h or 24d.`,
           });
         }
       }),

--- a/src/config/config.service.test.ts
+++ b/src/config/config.service.test.ts
@@ -337,6 +337,70 @@ describe('configSchema', () => {
     );
     expect(result.success).toBe(false);
   });
+
+  test('applies default for safety.evaluation_timeout', () => {
+    const result = configSchema.safeParse(validConfig());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.safety.evaluation_timeout).toBe('1h');
+    }
+  });
+
+  test('accepts common safety.evaluation_timeout values', () => {
+    for (const evaluation_timeout of ['1h', '30m']) {
+      const result = configSchema.safeParse(
+        validConfig({
+          safety: { evaluation_timeout, max_deletes_per_run: 50 },
+        }),
+      );
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.safety.evaluation_timeout).toBe(evaluation_timeout);
+      }
+    }
+  });
+
+  test('rejects invalid safety.evaluation_timeout duration', () => {
+    const result = configSchema.safeParse(
+      validConfig({
+        safety: { evaluation_timeout: 'banana', max_deletes_per_run: 50 },
+      }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects safety.evaluation_timeout above the 32-bit timer limit', () => {
+    const result = configSchema.safeParse(
+      validConfig({
+        safety: { evaluation_timeout: '30d', max_deletes_per_run: 50 },
+      }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain('24.8 days');
+    }
+  });
+
+  test('accepts safety.evaluation_timeout exactly at the 32-bit timer limit', () => {
+    const result = configSchema.safeParse(
+      validConfig({
+        safety: {
+          evaluation_timeout: '2147483647ms',
+          max_deletes_per_run: 50,
+        },
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts safety.evaluation_timeout just under the 32-bit timer limit', () => {
+    const result = configSchema.safeParse(
+      validConfig({
+        safety: { evaluation_timeout: '24d', max_deletes_per_run: 50 },
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('validateConfig (cross-validation)', () => {

--- a/src/evaluation/evaluation.e2e.test.ts
+++ b/src/evaluation/evaluation.e2e.test.ts
@@ -82,7 +82,11 @@ describe('full evaluation pipeline (e2e)', () => {
 
     // Step 5: Execute
     const { results: executedResults, executionSummary } =
-      await actionExecutor.execute(results, enrichedItems, dryRun);
+      await actionExecutor.execute({
+        results,
+        items: enrichedItems,
+        dryRun,
+      });
 
     if (executionSummary) {
       summary.actions_executed = executionSummary.actions_executed;

--- a/src/evaluation/evaluation.e2e.test.ts
+++ b/src/evaluation/evaluation.e2e.test.ts
@@ -12,6 +12,7 @@ import { StateService } from '../snapshot/state.service';
 import {
   createMockRadarrClient,
   createMockSonarrClient,
+  makeConfig,
   makeRadarrMovie,
   makeRule,
   useTestDatabase,
@@ -43,6 +44,7 @@ describe('full evaluation pipeline (e2e)', () => {
     actionExecutor = new ActionExecutorService(
       mockRadarrClient,
       createMockSonarrClient(),
+      { getConfig: () => makeConfig() } as any,
     );
   });
 

--- a/src/evaluation/evaluation.service.test.ts
+++ b/src/evaluation/evaluation.service.test.ts
@@ -58,7 +58,7 @@ describe('EvaluationService', () => {
       enrich: mock((items: any) => items),
     };
     actionExecutor = {
-      execute: mock((results: any) => Promise.resolve({ results })),
+      execute: mock(({ results }: any) => Promise.resolve({ results })),
     };
 
     service = new EvaluationService(
@@ -85,12 +85,12 @@ describe('EvaluationService', () => {
       expect(mediaService.hydrate).toHaveBeenCalledTimes(1);
       expect(rulesService.evaluate).toHaveBeenCalledTimes(1);
       expect(actionExecutor.execute).toHaveBeenCalledTimes(1);
-      expect(actionExecutor.execute).toHaveBeenCalledWith(
-        [testEvaluationResult],
-        [testMovie],
-        testConfig.dry_run,
-        expect.any(Function),
-      );
+      expect(actionExecutor.execute).toHaveBeenCalledWith({
+        results: [testEvaluationResult],
+        items: [testMovie],
+        dryRun: testConfig.dry_run,
+        isAbandoned: expect.any(Function),
+      });
     });
 
     test('filters out unmatched items from results', async () => {
@@ -353,7 +353,7 @@ describe('EvaluationService', () => {
         }),
       );
       const execute = heldStep<any>();
-      actionExecutor.execute = mock((results: any) =>
+      actionExecutor.execute = mock(({ results }: any) =>
         execute.promise.then(() => ({ results })),
       );
 
@@ -377,7 +377,7 @@ describe('EvaluationService', () => {
       let isAbandoned: (() => boolean) | undefined;
       const execute = heldStep<any>();
       actionExecutor.execute = mock(
-        (results: any, _items: any, _dryRun: any, abandoned: () => boolean) => {
+        ({ results, isAbandoned: abandoned }: any) => {
           isAbandoned = abandoned;
           return execute.promise.then(() => ({ results }));
         },
@@ -394,7 +394,7 @@ describe('EvaluationService', () => {
     });
 
     test('carries an execution abort reason into the run summary', async () => {
-      actionExecutor.execute = mock((results: any) =>
+      actionExecutor.execute = mock(({ results }: any) =>
         Promise.resolve({
           results,
           executionSummary: {

--- a/src/evaluation/evaluation.service.test.ts
+++ b/src/evaluation/evaluation.service.test.ts
@@ -288,6 +288,42 @@ describe('EvaluationService', () => {
       expect(actionExecutor.execute).not.toHaveBeenCalled();
     });
 
+    test('does not snapshot for a run that already timed out', async () => {
+      configService.getConfig = mock(() =>
+        makeConfig({
+          safety: { evaluation_timeout: '30ms', max_deletes_per_run: 50 },
+        }),
+      );
+      mediaService.hydrate = mock(
+        () =>
+          new Promise(resolve => setTimeout(() => resolve([testMovie]), 120)),
+      );
+
+      await service.runEvaluation();
+
+      await new Promise(resolve => setTimeout(resolve, 200));
+      expect(snapshotService.snapshot).not.toHaveBeenCalled();
+    });
+
+    test('does not report completed when the deadline elapses mid-execution', async () => {
+      configService.getConfig = mock(() =>
+        makeConfig({
+          safety: { evaluation_timeout: '30ms', max_deletes_per_run: 50 },
+        }),
+      );
+      actionExecutor.execute = mock(
+        (results: any) =>
+          new Promise(resolve => setTimeout(() => resolve({ results }), 120)),
+      );
+
+      const run = await service.runEvaluation();
+      expect(run.status).toBe('failed');
+
+      await new Promise(resolve => setTimeout(resolve, 200));
+      expect(run.status).toBe('failed');
+      expect(run.results).toEqual([]);
+    });
+
     test('completes normally when within the deadline', async () => {
       const run = await service.runEvaluation();
       expect(run.status).toBe('completed');

--- a/src/evaluation/evaluation.service.test.ts
+++ b/src/evaluation/evaluation.service.test.ts
@@ -89,6 +89,7 @@ describe('EvaluationService', () => {
         [testEvaluationResult],
         [testMovie],
         testConfig.dry_run,
+        expect.any(Function),
       );
     });
 
@@ -269,22 +270,37 @@ describe('EvaluationService', () => {
       expect(mediaService.hydrate).toHaveBeenCalledTimes(1);
     });
 
+    /**
+     * A pipeline step the test holds open. Nothing but `release` can settle it,
+     * so "the deadline fires first" is a fixed ordering rather than a race
+     * between two wall-clock timers on a loaded machine.
+     */
+    function heldStep<T>(): {
+      promise: Promise<T>;
+      release: (value: T) => void;
+    } {
+      let resolveStep: (value: T) => void = () => {};
+      const promise = new Promise<T>(resolve => {
+        resolveStep = resolve;
+      });
+      return { promise, release: value => resolveStep(value) };
+    }
+
     test('does not execute actions for a run that already timed out', async () => {
       configService.getConfig = mock(() =>
         makeConfig({
           safety: { evaluation_timeout: '30ms', max_deletes_per_run: 50 },
         }),
       );
-      // Settles well after the deadline has passed.
-      mediaService.hydrate = mock(
-        () =>
-          new Promise(resolve => setTimeout(() => resolve([testMovie]), 120)),
-      );
+      const hydrate = heldStep<any>();
+      mediaService.hydrate = mock(() => hydrate.promise);
 
       const run = await service.runEvaluation();
       expect(run.status).toBe('failed');
 
-      await new Promise(resolve => setTimeout(resolve, 200));
+      hydrate.release([testMovie]);
+      await tick();
+
       expect(actionExecutor.execute).not.toHaveBeenCalled();
     });
 
@@ -294,14 +310,14 @@ describe('EvaluationService', () => {
           safety: { evaluation_timeout: '30ms', max_deletes_per_run: 50 },
         }),
       );
-      mediaService.hydrate = mock(
-        () =>
-          new Promise(resolve => setTimeout(() => resolve([testMovie]), 120)),
-      );
+      const hydrate = heldStep<any>();
+      mediaService.hydrate = mock(() => hydrate.promise);
 
       await service.runEvaluation();
 
-      await new Promise(resolve => setTimeout(resolve, 200));
+      hydrate.release([testMovie]);
+      await tick();
+
       expect(snapshotService.snapshot).not.toHaveBeenCalled();
     });
 
@@ -311,17 +327,63 @@ describe('EvaluationService', () => {
           safety: { evaluation_timeout: '30ms', max_deletes_per_run: 50 },
         }),
       );
-      actionExecutor.execute = mock(
-        (results: any) =>
-          new Promise(resolve => setTimeout(() => resolve({ results }), 120)),
+      const execute = heldStep<any>();
+      actionExecutor.execute = mock((results: any) =>
+        execute.promise.then(() => ({ results })),
       );
 
       const run = await service.runEvaluation();
       expect(run.status).toBe('failed');
 
-      await new Promise(resolve => setTimeout(resolve, 200));
+      execute.release(null);
+      await tick();
+
       expect(run.status).toBe('failed');
       expect(run.results).toEqual([]);
+    });
+
+    test('tells the executor to stop once the run is abandoned', async () => {
+      configService.getConfig = mock(() =>
+        makeConfig({
+          safety: { evaluation_timeout: '30ms', max_deletes_per_run: 50 },
+        }),
+      );
+
+      let isAbandoned: (() => boolean) | undefined;
+      const execute = heldStep<any>();
+      actionExecutor.execute = mock(
+        (results: any, _items: any, _dryRun: any, abandoned: () => boolean) => {
+          isAbandoned = abandoned;
+          return execute.promise.then(() => ({ results }));
+        },
+      );
+
+      const run = await service.runEvaluation();
+      expect(run.status).toBe('failed');
+
+      // The executor is still mid-queue here; its next poll must say stop.
+      expect(isAbandoned?.()).toBe(true);
+
+      execute.release(null);
+      await tick();
+    });
+
+    test('carries an execution abort reason into the run summary', async () => {
+      actionExecutor.execute = mock((results: any) =>
+        Promise.resolve({
+          results,
+          executionSummary: {
+            actions_executed: { keep: 0, unmonitor: 0, delete: 0 },
+            actions_failed: 0,
+            aborted_reason: 'max_deletes_per_run_exceeded' as const,
+          },
+        }),
+      );
+
+      const run = await service.runEvaluation();
+
+      expect(run.status).toBe('completed');
+      expect(run.summary?.aborted_reason).toBe('max_deletes_per_run_exceeded');
     });
 
     test('completes normally when within the deadline', async () => {

--- a/src/evaluation/evaluation.service.test.ts
+++ b/src/evaluation/evaluation.service.test.ts
@@ -321,6 +321,31 @@ describe('EvaluationService', () => {
       expect(snapshotService.snapshot).not.toHaveBeenCalled();
     });
 
+    test('does not evaluate rules when the deadline elapses during the snapshot', async () => {
+      configService.getConfig = mock(() =>
+        makeConfig({
+          safety: { evaluation_timeout: '30ms', max_deletes_per_run: 50 },
+        }),
+      );
+      const snapshot = heldStep<void>();
+      snapshotService.snapshot = mock(() => snapshot.promise);
+
+      const run = await service.runEvaluation();
+      expect(run.status).toBe('failed');
+
+      // The snapshot rows land regardless — but rule evaluation writes audit
+      // entries, and an abandoned run must not leave an audit trail behind.
+      snapshot.release();
+      await tick();
+
+      expect(snapshotService.snapshot).toHaveBeenCalledTimes(1);
+      expect(rulesService.evaluate).not.toHaveBeenCalled();
+      expect(stateService.enrich).not.toHaveBeenCalled();
+      expect(actionExecutor.execute).not.toHaveBeenCalled();
+      expect(run.status).toBe('failed');
+      expect(run.results).toEqual([]);
+    });
+
     test('does not report completed when the deadline elapses mid-execution', async () => {
       configService.getConfig = mock(() =>
         makeConfig({

--- a/src/evaluation/evaluation.service.test.ts
+++ b/src/evaluation/evaluation.service.test.ts
@@ -236,4 +236,62 @@ describe('EvaluationService', () => {
       expect(mediaService.hydrate).toHaveBeenCalledTimes(1);
     });
   });
+  describe('evaluation deadline (safety.evaluation_timeout)', () => {
+    test('releases the scheduler when hydrate never settles', async () => {
+      configService.getConfig = mock(() =>
+        makeConfig({
+          safety: { evaluation_timeout: '50ms', max_deletes_per_run: 50 },
+        }),
+      );
+      // A promise that never settles — the production wedge, reproduced.
+      mediaService.hydrate = mock(() => new Promise(() => {}));
+
+      const run = await service.runEvaluation();
+
+      expect(service.isRunning()).toBe(false);
+      expect(run.status).toBe('failed');
+      expect(run.error).toContain('50ms');
+    });
+
+    test('a later cron run proceeds after a timed-out run', async () => {
+      configService.getConfig = mock(() =>
+        makeConfig({
+          schedule: '* * * * *',
+          safety: { evaluation_timeout: '50ms', max_deletes_per_run: 50 },
+        }),
+      );
+      mediaService.hydrate = mock(() => new Promise(() => {}));
+      await service.handleCron();
+      expect(service.isRunning()).toBe(false);
+
+      mediaService.hydrate = mock(() => Promise.resolve([testMovie]));
+      await service.handleCron();
+      expect(mediaService.hydrate).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not execute actions for a run that already timed out', async () => {
+      configService.getConfig = mock(() =>
+        makeConfig({
+          safety: { evaluation_timeout: '30ms', max_deletes_per_run: 50 },
+        }),
+      );
+      // Settles well after the deadline has passed.
+      mediaService.hydrate = mock(
+        () =>
+          new Promise(resolve => setTimeout(() => resolve([testMovie]), 120)),
+      );
+
+      const run = await service.runEvaluation();
+      expect(run.status).toBe('failed');
+
+      await new Promise(resolve => setTimeout(resolve, 200));
+      expect(actionExecutor.execute).not.toHaveBeenCalled();
+    });
+
+    test('completes normally when within the deadline', async () => {
+      const run = await service.runEvaluation();
+      expect(run.status).toBe('completed');
+      expect(service.isRunning()).toBe(false);
+    });
+  });
 });

--- a/src/evaluation/evaluation.service.ts
+++ b/src/evaluation/evaluation.service.ts
@@ -197,12 +197,17 @@ export class EvaluationService {
    * which is the closest a non-cancellable pipeline can get to stopping.
    */
   private isAbandoned(run: EvaluationRun): boolean {
-    if (run.status === 'running') return false;
+    if (!this.hasBeenAbandoned(run)) return false;
 
     this.logger.warn(
       `Evaluation ${run.run_id} continued after being abandoned — discarding its results`,
     );
     return true;
+  }
+
+  /** Silent form of {@link isAbandoned}, for polling inside a loop. */
+  private hasBeenAbandoned(run: EvaluationRun): boolean {
+    return run.status !== 'running';
   }
 
   private async runPipeline(run: EvaluationRun): Promise<void> {
@@ -236,11 +241,17 @@ export class EvaluationService {
 
     // Step 5: Execute actions (no-op in dry-run mode)
     const { results: executedResults, executionSummary } =
-      await this.actionExecutor.execute(results, enrichedItems, run.dry_run);
+      await this.actionExecutor.execute(
+        results,
+        enrichedItems,
+        run.dry_run,
+        () => this.hasBeenAbandoned(run),
+      );
 
     if (executionSummary) {
       summary.actions_executed = executionSummary.actions_executed;
       summary.actions_failed = executionSummary.actions_failed;
+      summary.aborted_reason = executionSummary.aborted_reason;
     }
 
     if (this.isAbandoned(run)) return;
@@ -261,6 +272,7 @@ export class EvaluationService {
       rules_skipped_missing_data: summary.rules_skipped_missing_data,
       actions_executed: summary.actions_executed ?? null,
       actions_failed: summary.actions_failed ?? null,
+      aborted_reason: summary.aborted_reason ?? null,
     });
   }
 

--- a/src/evaluation/evaluation.service.ts
+++ b/src/evaluation/evaluation.service.ts
@@ -226,6 +226,12 @@ export class EvaluationService {
     const hydratedServices = getHydratedServices(rules);
     await this.snapshotService.snapshot(items, hydratedServices);
 
+    // The snapshot rows are already written by the time this returns — this
+    // guard cannot unwrite them. What it stops is everything downstream: rule
+    // evaluation emits audit-log entries as a side effect, and an abandoned run
+    // must not leave an audit trail for a run already recorded as failed.
+    if (this.isAbandoned(run)) return;
+
     // Step 3: Enrich — compute temporal state fields from change history
     const enrichedItems = this.stateService.enrich(items);
 

--- a/src/evaluation/evaluation.service.ts
+++ b/src/evaluation/evaluation.service.ts
@@ -247,12 +247,12 @@ export class EvaluationService {
 
     // Step 5: Execute actions (no-op in dry-run mode)
     const { results: executedResults, executionSummary } =
-      await this.actionExecutor.execute(
+      await this.actionExecutor.execute({
         results,
-        enrichedItems,
-        run.dry_run,
-        () => this.hasBeenAbandoned(run),
-      );
+        items: enrichedItems,
+        dryRun: run.dry_run,
+        isAbandoned: () => this.hasBeenAbandoned(run),
+      });
 
     if (executionSummary) {
       summary.actions_executed = executionSummary.actions_executed;

--- a/src/evaluation/evaluation.service.ts
+++ b/src/evaluation/evaluation.service.ts
@@ -187,6 +187,24 @@ export class EvaluationService {
     }
   }
 
+  /**
+   * Whether this run has been abandoned by its deadline.
+   *
+   * A timed-out run is already marked failed and the scheduler has been
+   * released, so a later evaluation may be underway. The abandoned pipeline can
+   * still settle at any await point; when it does it must not write state,
+   * execute actions, or report itself completed. Checked at each step boundary,
+   * which is the closest a non-cancellable pipeline can get to stopping.
+   */
+  private isAbandoned(run: EvaluationRun): boolean {
+    if (run.status === 'running') return false;
+
+    this.logger.warn(
+      `Evaluation ${run.run_id} continued after being abandoned — discarding its results`,
+    );
+    return true;
+  }
+
   private async runPipeline(run: EvaluationRun): Promise<void> {
     const config = this.configService.getConfig();
     const { rules } = config;
@@ -197,6 +215,7 @@ export class EvaluationService {
 
     // Step 1: Hydrate unified models from all services
     const items = await this.mediaService.hydrate(rules);
+    if (this.isAbandoned(run)) return;
 
     // Step 2: Snapshot — persist unified models, detect field changes
     const hydratedServices = getHydratedServices(rules);
@@ -213,14 +232,7 @@ export class EvaluationService {
       run.dry_run,
     );
 
-    // A run that already timed out has released the scheduler; another
-    // evaluation may be underway. Never let a zombie pipeline execute actions.
-    if (run.status !== 'running') {
-      this.logger.warn(
-        `Evaluation ${run.run_id} finished after being abandoned — discarding results without executing actions`,
-      );
-      return;
-    }
+    if (this.isAbandoned(run)) return;
 
     // Step 5: Execute actions (no-op in dry-run mode)
     const { results: executedResults, executionSummary } =
@@ -230,6 +242,8 @@ export class EvaluationService {
       summary.actions_executed = executionSummary.actions_executed;
       summary.actions_failed = executionSummary.actions_failed;
     }
+
+    if (this.isAbandoned(run)) return;
 
     // Step 6: Update run with results
     run.status = 'completed';

--- a/src/evaluation/evaluation.service.ts
+++ b/src/evaluation/evaluation.service.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
+import parseDuration from 'parse-duration';
 import { ConfigService } from '../config/config.service';
 import { matchesCron } from '../config/cron';
 import { getHydratedServices } from '../config/field-registry';
@@ -12,6 +13,14 @@ import { StateService } from '../snapshot/state.service';
 import type { EvaluationRun } from './evaluation.types';
 
 const MAX_STORED_RUNS = 10;
+
+/** Raised when an evaluation exceeds its configured wall-clock budget. */
+class EvaluationTimeoutError extends Error {
+  constructor(timeout: string) {
+    super(`Evaluation exceeded its ${timeout} budget and was abandoned`);
+    this.name = 'EvaluationTimeoutError';
+  }
+}
 
 @Injectable()
 export class EvaluationService {
@@ -121,58 +130,14 @@ export class EvaluationService {
   }
 
   private async executeEvaluation(run: EvaluationRun): Promise<void> {
+    const { evaluation_timeout } = this.configService.getConfig().safety;
+
     try {
-      const config = this.configService.getConfig();
-      const { rules } = config;
-
-      this.logger.log(
-        `Evaluation ${run.run_id} started: ${rules.length} rules to evaluate`,
-      );
-
-      // Step 1: Hydrate unified models from all services
-      const items = await this.mediaService.hydrate(rules);
-
-      // Step 2: Snapshot — persist unified models, detect field changes
-      const hydratedServices = getHydratedServices(rules);
-      await this.snapshotService.snapshot(items, hydratedServices);
-
-      // Step 3: Enrich — compute temporal state fields from change history
-      const enrichedItems = this.stateService.enrich(items);
-
-      // Step 4: Evaluate rules against all items
-      const { results, summary } = this.rulesService.evaluate(
-        enrichedItems,
-        rules,
+      await this.withDeadline(
+        this.runPipeline(run),
+        evaluation_timeout,
         run.run_id,
-        run.dry_run,
       );
-
-      // Step 5: Execute actions (no-op in dry-run mode)
-      const { results: executedResults, executionSummary } =
-        await this.actionExecutor.execute(results, enrichedItems, run.dry_run);
-
-      if (executionSummary) {
-        summary.actions_executed = executionSummary.actions_executed;
-        summary.actions_failed = executionSummary.actions_failed;
-      }
-
-      // Step 6: Update run with results
-      run.status = 'completed';
-      run.completed_at = new Date().toISOString();
-      run.summary = summary;
-      run.results = executedResults.filter(r => r.resolved_action !== null);
-
-      this.logger.log({
-        msg: `Evaluation ${run.run_id} completed`,
-        run_id: run.run_id,
-        dry_run: run.dry_run,
-        items_evaluated: summary.items_evaluated,
-        items_matched: summary.items_matched,
-        actions: summary.actions,
-        rules_skipped_missing_data: summary.rules_skipped_missing_data,
-        actions_executed: summary.actions_executed ?? null,
-        actions_failed: summary.actions_failed ?? null,
-      });
     } catch (error) {
       run.status = 'failed';
       run.completed_at = new Date().toISOString();
@@ -183,6 +148,106 @@ export class EvaluationService {
     } finally {
       this.running = false;
     }
+  }
+
+  /**
+   * Race a pipeline against its wall-clock budget.
+   *
+   * On timeout the pipeline promise is abandoned rather than cancelled — it may
+   * never settle, which is precisely the failure being defended against. What
+   * matters is that this method returns, so the caller's `finally` can release
+   * the scheduler.
+   */
+  private async withDeadline(
+    pipeline: Promise<void>,
+    timeout: string,
+    runId: string,
+  ): Promise<void> {
+    const ms = parseDuration(timeout);
+    if (ms === null || ms <= 0) {
+      throw new Error(`Invalid safety.evaluation_timeout: "${timeout}"`);
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      await Promise.race([
+        pipeline,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            this.logger.error(
+              `Evaluation ${runId} exceeded its ${timeout} budget — abandoning the run and releasing the scheduler. The next scheduled evaluation will proceed normally.`,
+            );
+            reject(new EvaluationTimeoutError(timeout));
+          }, ms);
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private async runPipeline(run: EvaluationRun): Promise<void> {
+    const config = this.configService.getConfig();
+    const { rules } = config;
+
+    this.logger.log(
+      `Evaluation ${run.run_id} started: ${rules.length} rules to evaluate`,
+    );
+
+    // Step 1: Hydrate unified models from all services
+    const items = await this.mediaService.hydrate(rules);
+
+    // Step 2: Snapshot — persist unified models, detect field changes
+    const hydratedServices = getHydratedServices(rules);
+    await this.snapshotService.snapshot(items, hydratedServices);
+
+    // Step 3: Enrich — compute temporal state fields from change history
+    const enrichedItems = this.stateService.enrich(items);
+
+    // Step 4: Evaluate rules against all items
+    const { results, summary } = this.rulesService.evaluate(
+      enrichedItems,
+      rules,
+      run.run_id,
+      run.dry_run,
+    );
+
+    // A run that already timed out has released the scheduler; another
+    // evaluation may be underway. Never let a zombie pipeline execute actions.
+    if (run.status !== 'running') {
+      this.logger.warn(
+        `Evaluation ${run.run_id} finished after being abandoned — discarding results without executing actions`,
+      );
+      return;
+    }
+
+    // Step 5: Execute actions (no-op in dry-run mode)
+    const { results: executedResults, executionSummary } =
+      await this.actionExecutor.execute(results, enrichedItems, run.dry_run);
+
+    if (executionSummary) {
+      summary.actions_executed = executionSummary.actions_executed;
+      summary.actions_failed = executionSummary.actions_failed;
+    }
+
+    // Step 6: Update run with results
+    run.status = 'completed';
+    run.completed_at = new Date().toISOString();
+    run.summary = summary;
+    run.results = executedResults.filter(r => r.resolved_action !== null);
+
+    this.logger.log({
+      msg: `Evaluation ${run.run_id} completed`,
+      run_id: run.run_id,
+      dry_run: run.dry_run,
+      items_evaluated: summary.items_evaluated,
+      items_matched: summary.items_matched,
+      actions: summary.actions,
+      rules_skipped_missing_data: summary.rules_skipped_missing_data,
+      actions_executed: summary.actions_executed ?? null,
+      actions_failed: summary.actions_failed ?? null,
+    });
   }
 
   /**

--- a/src/execution/action-executor.service.test.ts
+++ b/src/execution/action-executor.service.test.ts
@@ -54,6 +54,9 @@ describe('ActionExecutorService', () => {
   };
   let service: ActionExecutorService;
 
+  const execute = (options: Parameters<ActionExecutorService['execute']>[0]) =>
+    service.execute(options);
+
   beforeEach(() => {
     radarrClient = {
       deleteMovie: mock(() => Promise.resolve()),
@@ -115,11 +118,11 @@ describe('ActionExecutorService', () => {
       const movie = makeMovie();
       const result = makeResult(movie, 'delete');
 
-      const { results, executionSummary } = await service.execute(
-        [result],
-        [movie],
-        true,
-      );
+      const { results, executionSummary } = await execute({
+        results: [result],
+        items: [movie],
+        dryRun: true,
+      });
 
       expect(results[0].execution_status).toBe('skipped');
       expect(executionSummary).toBeUndefined();
@@ -132,7 +135,11 @@ describe('ActionExecutorService', () => {
       const movie = makeMovie();
       const result = makeResult(movie, 'delete');
 
-      const { results } = await service.execute([result], [movie], false);
+      const { results } = await execute({
+        results: [result],
+        items: [movie],
+        dryRun: false,
+      });
 
       expect(radarrClient.deleteMovie).toHaveBeenCalledWith(101);
       expect(results[0].execution_status).toBe('success');
@@ -144,13 +151,36 @@ describe('ActionExecutorService', () => {
       const movie = makeMovie();
       const result = makeResult(movie, 'unmonitor');
 
-      const { results } = await service.execute([result], [movie], false);
+      const { results } = await execute({
+        results: [result],
+        items: [movie],
+        dryRun: false,
+      });
 
       expect(radarrClient.fetchMovie).toHaveBeenCalledWith(101);
       expect(radarrClient.updateMovie).toHaveBeenCalledTimes(1);
       const putBody = radarrClient.updateMovie.mock.calls[0][1];
       expect(putBody.monitored).toBe(false);
       expect(results[0].execution_status).toBe('success');
+    });
+
+    test('does not update a movie after the run is abandoned', async () => {
+      let abandoned = false;
+      radarrClient.fetchMovie = mock(() => {
+        abandoned = true;
+        return Promise.resolve(makeRadarrMovie({ id: 101, monitored: true }));
+      });
+      const movie = makeMovie();
+
+      const { executionSummary } = await execute({
+        results: [makeResult(movie, 'unmonitor')],
+        items: [movie],
+        dryRun: false,
+        isAbandoned: () => abandoned,
+      });
+
+      expect(radarrClient.updateMovie).not.toHaveBeenCalled();
+      expect(executionSummary?.aborted_reason).toBe('evaluation_abandoned');
     });
   });
 
@@ -159,7 +189,11 @@ describe('ActionExecutorService', () => {
       const season = makeSeason();
       const result = makeResult(season, 'delete');
 
-      const { results } = await service.execute([result], [season], false);
+      const { results } = await execute({
+        results: [result],
+        items: [season],
+        dryRun: false,
+      });
 
       expect(sonarrClient.fetchEpisodeFiles).toHaveBeenCalledWith(201);
       // Only season 1 files (ids 1 and 2), not season 2 (id 3)
@@ -180,7 +214,11 @@ describe('ActionExecutorService', () => {
       const season = makeSeason();
       const result = makeResult(season, 'delete');
 
-      const { results } = await service.execute([result], [season], false);
+      const { results } = await execute({
+        results: [result],
+        items: [season],
+        dryRun: false,
+      });
 
       expect(sonarrClient.deleteEpisodeFile).toHaveBeenCalledTimes(2);
       expect(sonarrClient.deleteEpisodeFile).toHaveBeenCalledWith(1);
@@ -193,10 +231,34 @@ describe('ActionExecutorService', () => {
       const season = makeSeason();
       const result = makeResult(season, 'delete');
 
-      const { results } = await service.execute([result], [season], false);
+      const { results } = await execute({
+        results: [result],
+        items: [season],
+        dryRun: false,
+      });
 
       expect(sonarrClient.deleteEpisodeFile).not.toHaveBeenCalled();
       expect(results[0].execution_status).toBe('success');
+    });
+
+    test('stops deleting episode files when the run is abandoned', async () => {
+      let abandoned = false;
+      sonarrClient.deleteEpisodeFile = mock(() => {
+        abandoned = true;
+        return Promise.resolve();
+      });
+      const season = makeSeason();
+      const result = makeResult(season, 'delete');
+
+      const { executionSummary } = await execute({
+        results: [result],
+        items: [season],
+        dryRun: false,
+        isAbandoned: () => abandoned,
+      });
+
+      expect(sonarrClient.deleteEpisodeFile).toHaveBeenCalledTimes(1);
+      expect(executionSummary?.aborted_reason).toBe('evaluation_abandoned');
     });
   });
 
@@ -205,7 +267,11 @@ describe('ActionExecutorService', () => {
       const season = makeSeason();
       const result = makeResult(season, 'unmonitor');
 
-      const { results } = await service.execute([result], [season], false);
+      const { results } = await execute({
+        results: [result],
+        items: [season],
+        dryRun: false,
+      });
 
       expect(sonarrClient.fetchSeriesById).toHaveBeenCalledWith(201);
       expect(sonarrClient.updateSeries).toHaveBeenCalledTimes(1);
@@ -214,6 +280,25 @@ describe('ActionExecutorService', () => {
       expect(putBody.seasons[1].monitored).toBe(true); // season 2 unchanged
       expect(results[0].execution_status).toBe('success');
     });
+
+    test('does not update a series after the run is abandoned', async () => {
+      let abandoned = false;
+      sonarrClient.fetchSeriesById = mock(() => {
+        abandoned = true;
+        return Promise.resolve(makeSonarrSeries());
+      });
+      const season = makeSeason();
+
+      const { executionSummary } = await execute({
+        results: [makeResult(season, 'unmonitor')],
+        items: [season],
+        dryRun: false,
+        isAbandoned: () => abandoned,
+      });
+
+      expect(sonarrClient.updateSeries).not.toHaveBeenCalled();
+      expect(executionSummary?.aborted_reason).toBe('evaluation_abandoned');
+    });
   });
 
   describe('keep actions', () => {
@@ -221,7 +306,11 @@ describe('ActionExecutorService', () => {
       const movie = makeMovie();
       const result = makeResult(movie, 'keep');
 
-      const { results } = await service.execute([result], [movie], false);
+      const { results } = await execute({
+        results: [result],
+        items: [movie],
+        dryRun: false,
+      });
 
       expect(radarrClient.deleteMovie).not.toHaveBeenCalled();
       expect(radarrClient.fetchMovie).not.toHaveBeenCalled();
@@ -232,7 +321,11 @@ describe('ActionExecutorService', () => {
       const movie = makeMovie();
       const result = makeResult(movie, null);
 
-      const { results } = await service.execute([result], [movie], false);
+      const { results } = await execute({
+        results: [result],
+        items: [movie],
+        dryRun: false,
+      });
 
       expect(radarrClient.deleteMovie).not.toHaveBeenCalled();
       expect(results[0].execution_status).toBe('skipped');
@@ -245,11 +338,11 @@ describe('ActionExecutorService', () => {
       const movie = makeMovie();
       const result = makeResult(movie, 'delete');
 
-      const { results, executionSummary } = await service.execute(
-        [result],
-        [movie],
-        false,
-      );
+      const { results, executionSummary } = await execute({
+        results: [result],
+        items: [movie],
+        dryRun: false,
+      });
 
       expect(results).toHaveLength(1);
       expect(results[0].execution_status).toBe('not_found');
@@ -275,11 +368,11 @@ describe('ActionExecutorService', () => {
         makeResult(movie2, 'delete'),
       ];
 
-      const { results: executed, executionSummary } = await service.execute(
+      const { results: executed, executionSummary } = await execute({
         results,
-        [movie1, movie2],
-        false,
-      );
+        items: [movie1, movie2],
+        dryRun: false,
+      });
 
       expect(executed[0].execution_status).toBe('failed');
       expect(executed[0].execution_error).toBe('Internal Server Error');
@@ -300,11 +393,11 @@ describe('ActionExecutorService', () => {
         return Promise.resolve();
       });
 
-      const { results: executed, executionSummary } = await service.execute(
-        [makeResult(movie1, 'delete'), makeResult(movie2, 'delete')],
-        [movie1, movie2],
-        false,
-      );
+      const { results: executed, executionSummary } = await execute({
+        results: [makeResult(movie1, 'delete'), makeResult(movie2, 'delete')],
+        items: [movie1, movie2],
+        dryRun: false,
+      });
 
       expect(executed).toHaveLength(2);
       expect(executed[0].execution_status).toBe('not_found');
@@ -319,7 +412,11 @@ describe('ActionExecutorService', () => {
       const result = makeResult(movie, 'delete');
 
       // Pass empty items array — item won't be found
-      const { results } = await service.execute([result], [], false);
+      const { results } = await execute({
+        results: [result],
+        items: [],
+        dryRun: false,
+      });
 
       expect(results[0].execution_status).toBe('failed');
       expect(results[0].execution_error).toBe(
@@ -340,11 +437,11 @@ describe('ActionExecutorService', () => {
       const season = makeSeason();
       const result = makeResult(season, 'unmonitor');
 
-      const { results, executionSummary } = await service.execute(
-        [result],
-        [season],
-        false,
-      );
+      const { results, executionSummary } = await execute({
+        results: [result],
+        items: [season],
+        dryRun: false,
+      });
 
       expect(results[0].execution_status).toBe('failed');
       expect(results[0].execution_error).toBe(
@@ -361,11 +458,11 @@ describe('ActionExecutorService', () => {
       const season = makeSeason();
       const result = makeResult(season, 'delete');
 
-      const { results, executionSummary } = await service.execute(
-        [result],
-        [season],
-        false,
-      );
+      const { results, executionSummary } = await execute({
+        results: [result],
+        items: [season],
+        dryRun: false,
+      });
 
       expect(results[0].execution_status).toBe('failed');
       expect(results[0].execution_error).toBe('Connection refused');
@@ -385,11 +482,11 @@ describe('ActionExecutorService', () => {
         makeResult(season, 'delete'),
       ];
 
-      const { executionSummary } = await service.execute(
+      const { executionSummary } = await execute({
         results,
-        [movie1, movie2, season],
-        false,
-      );
+        items: [movie1, movie2, season],
+        dryRun: false,
+      });
 
       expect(executionSummary).toBeDefined();
       expect(executionSummary?.actions_executed.delete).toBe(2);
@@ -419,12 +516,12 @@ describe('ActionExecutorService', () => {
         },
       );
 
-      const { results: out, executionSummary } = await service.execute(
+      const { results: out, executionSummary } = await execute({
         results,
-        movies,
-        false,
-        () => abandoned,
-      );
+        items: movies,
+        dryRun: false,
+        isAbandoned: () => abandoned,
+      });
 
       expect(radarrClient.deleteMovie).toHaveBeenCalledTimes(2);
       expect(executionSummary?.aborted_reason).toBe('evaluation_abandoned');
@@ -438,12 +535,12 @@ describe('ActionExecutorService', () => {
     test('executes nothing when abandoned before the first action', async () => {
       const { movies, results } = makeDeletes(3);
 
-      const { results: out, executionSummary } = await service.execute(
+      const { results: out, executionSummary } = await execute({
         results,
-        movies,
-        false,
-        () => true,
-      );
+        items: movies,
+        dryRun: false,
+        isAbandoned: () => true,
+      });
 
       expect(radarrClient.deleteMovie).not.toHaveBeenCalled();
       expect(out.every(r => r.execution_status === 'skipped')).toBe(true);
@@ -453,12 +550,12 @@ describe('ActionExecutorService', () => {
     test('runs to completion when never abandoned', async () => {
       const { movies, results } = makeDeletes(3);
 
-      const { executionSummary } = await service.execute(
+      const { executionSummary } = await execute({
         results,
-        movies,
-        false,
-        () => false,
-      );
+        items: movies,
+        dryRun: false,
+        isAbandoned: () => false,
+      });
 
       expect(radarrClient.deleteMovie).toHaveBeenCalledTimes(3);
       expect(executionSummary?.aborted_reason).toBeUndefined();
@@ -491,11 +588,11 @@ describe('ActionExecutorService', () => {
       const { movies, results } = makeDeletes(4);
       const limited = serviceWithLimit(3);
 
-      const { results: out, executionSummary } = await limited.execute(
+      const { results: out, executionSummary } = await limited.execute({
         results,
-        movies,
-        false,
-      );
+        items: movies,
+        dryRun: false,
+      });
 
       expect(radarrClient.deleteMovie).not.toHaveBeenCalled();
       expect(out.every(r => r.execution_status === 'skipped')).toBe(true);
@@ -509,11 +606,11 @@ describe('ActionExecutorService', () => {
       const { movies, results } = makeDeletes(3);
       const limited = serviceWithLimit(3);
 
-      const { executionSummary } = await limited.execute(
+      const { executionSummary } = await limited.execute({
         results,
-        movies,
-        false,
-      );
+        items: movies,
+        dryRun: false,
+      });
 
       expect(radarrClient.deleteMovie).toHaveBeenCalledTimes(3);
       expect(executionSummary?.aborted_reason).toBeUndefined();
@@ -524,7 +621,7 @@ describe('ActionExecutorService', () => {
       const { movies, results } = makeDeletes(25);
       const limited = serviceWithLimit(null);
 
-      await limited.execute(results, movies, false);
+      await limited.execute({ results, items: movies, dryRun: false });
 
       expect(radarrClient.deleteMovie).toHaveBeenCalledTimes(25);
     });
@@ -536,11 +633,11 @@ describe('ActionExecutorService', () => {
       const { movies, results } = makeDeletes(2);
       const limited = serviceWithLimit(3);
 
-      const { executionSummary } = await limited.execute(
-        [...keeps.map(m => makeResult(m, 'keep')), ...results],
-        [...keeps, ...movies],
-        false,
-      );
+      const { executionSummary } = await limited.execute({
+        results: [...keeps.map(m => makeResult(m, 'keep')), ...results],
+        items: [...keeps, ...movies],
+        dryRun: false,
+      });
 
       expect(executionSummary?.aborted_reason).toBeUndefined();
       expect(radarrClient.deleteMovie).toHaveBeenCalledTimes(2);

--- a/src/execution/action-executor.service.test.ts
+++ b/src/execution/action-executor.service.test.ts
@@ -397,6 +397,74 @@ describe('ActionExecutorService', () => {
       expect(executionSummary?.actions_failed).toBe(0);
     });
   });
+  describe('abandonment mid-queue', () => {
+    function makeDeletes(count: number) {
+      const movies = Array.from({ length: count }, (_, i) =>
+        makeMovie({ radarr_id: 600 + i, tmdb_id: 7000 + i }),
+      );
+      return { movies, results: movies.map(m => makeResult(m, 'delete')) };
+    }
+
+    test('stops executing once the run is abandoned', async () => {
+      const { movies, results } = makeDeletes(5);
+
+      // Abandoned after the second delete lands.
+      let abandoned = false;
+      (radarrClient.deleteMovie as ReturnType<typeof mock>).mockImplementation(
+        () => {
+          if ((radarrClient.deleteMovie as any).mock.calls.length >= 2) {
+            abandoned = true;
+          }
+          return Promise.resolve();
+        },
+      );
+
+      const { results: out, executionSummary } = await service.execute(
+        results,
+        movies,
+        false,
+        () => abandoned,
+      );
+
+      expect(radarrClient.deleteMovie).toHaveBeenCalledTimes(2);
+      expect(executionSummary?.aborted_reason).toBe('evaluation_abandoned');
+      expect(executionSummary?.actions_executed.delete).toBe(2);
+
+      // Every result is still accounted for, so nothing looks silently dropped.
+      expect(out).toHaveLength(5);
+      expect(out.filter(r => r.execution_status === 'skipped')).toHaveLength(3);
+    });
+
+    test('executes nothing when abandoned before the first action', async () => {
+      const { movies, results } = makeDeletes(3);
+
+      const { results: out, executionSummary } = await service.execute(
+        results,
+        movies,
+        false,
+        () => true,
+      );
+
+      expect(radarrClient.deleteMovie).not.toHaveBeenCalled();
+      expect(out.every(r => r.execution_status === 'skipped')).toBe(true);
+      expect(executionSummary?.aborted_reason).toBe('evaluation_abandoned');
+    });
+
+    test('runs to completion when never abandoned', async () => {
+      const { movies, results } = makeDeletes(3);
+
+      const { executionSummary } = await service.execute(
+        results,
+        movies,
+        false,
+        () => false,
+      );
+
+      expect(radarrClient.deleteMovie).toHaveBeenCalledTimes(3);
+      expect(executionSummary?.aborted_reason).toBeUndefined();
+    });
+  });
+
   describe('safety.max_deletes_per_run', () => {
     /** N distinct movies each resolved to `delete`. */
     function makeDeletes(count: number) {

--- a/src/execution/action-executor.service.test.ts
+++ b/src/execution/action-executor.service.test.ts
@@ -5,6 +5,7 @@ import type { EvaluationItemResult } from '../rules/types';
 import { buildInternalId, type UnifiedMedia } from '../shared/types';
 import type { SonarrClient } from '../sonarr/sonarr.client';
 import {
+  makeConfig,
   makeMovie,
   makeRadarrMovie,
   makeSeason,
@@ -105,6 +106,7 @@ describe('ActionExecutorService', () => {
     service = new ActionExecutorService(
       radarrClient as unknown as RadarrClient,
       sonarrClient as unknown as SonarrClient,
+      { getConfig: () => makeConfig() } as any,
     );
   });
 
@@ -393,6 +395,87 @@ describe('ActionExecutorService', () => {
       expect(executionSummary?.actions_executed.delete).toBe(2);
       expect(executionSummary?.actions_executed.unmonitor).toBe(1);
       expect(executionSummary?.actions_failed).toBe(0);
+    });
+  });
+  describe('safety.max_deletes_per_run', () => {
+    /** N distinct movies each resolved to `delete`. */
+    function makeDeletes(count: number) {
+      const movies = Array.from({ length: count }, (_, i) =>
+        makeMovie({ radarr_id: 500 + i, tmdb_id: 9000 + i }),
+      );
+      return { movies, results: movies.map(m => makeResult(m, 'delete')) };
+    }
+
+    function serviceWithLimit(max_deletes_per_run: number | null) {
+      return new ActionExecutorService(
+        radarrClient as unknown as RadarrClient,
+        sonarrClient as unknown as SonarrClient,
+        {
+          getConfig: () =>
+            makeConfig({
+              safety: { evaluation_timeout: '1h', max_deletes_per_run },
+            }),
+        } as any,
+      );
+    }
+
+    test('executes nothing when resolved deletes exceed the limit', async () => {
+      const { movies, results } = makeDeletes(4);
+      const limited = serviceWithLimit(3);
+
+      const { results: out, executionSummary } = await limited.execute(
+        results,
+        movies,
+        false,
+      );
+
+      expect(radarrClient.deleteMovie).not.toHaveBeenCalled();
+      expect(out.every(r => r.execution_status === 'skipped')).toBe(true);
+      expect(executionSummary?.aborted_reason).toBe(
+        'max_deletes_per_run_exceeded',
+      );
+      expect(executionSummary?.actions_executed.delete).toBe(0);
+    });
+
+    test('executes normally when deletes are at the limit', async () => {
+      const { movies, results } = makeDeletes(3);
+      const limited = serviceWithLimit(3);
+
+      const { executionSummary } = await limited.execute(
+        results,
+        movies,
+        false,
+      );
+
+      expect(radarrClient.deleteMovie).toHaveBeenCalledTimes(3);
+      expect(executionSummary?.aborted_reason).toBeUndefined();
+      expect(executionSummary?.actions_executed.delete).toBe(3);
+    });
+
+    test('null disables the limit', async () => {
+      const { movies, results } = makeDeletes(25);
+      const limited = serviceWithLimit(null);
+
+      await limited.execute(results, movies, false);
+
+      expect(radarrClient.deleteMovie).toHaveBeenCalledTimes(25);
+    });
+
+    test('keep actions do not count toward the delete limit', async () => {
+      const keeps = Array.from({ length: 30 }, (_, i) =>
+        makeMovie({ radarr_id: 700 + i, tmdb_id: 8000 + i }),
+      );
+      const { movies, results } = makeDeletes(2);
+      const limited = serviceWithLimit(3);
+
+      const { executionSummary } = await limited.execute(
+        [...keeps.map(m => makeResult(m, 'keep')), ...results],
+        [...keeps, ...movies],
+        false,
+      );
+
+      expect(executionSummary?.aborted_reason).toBeUndefined();
+      expect(radarrClient.deleteMovie).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/execution/action-executor.service.ts
+++ b/src/execution/action-executor.service.ts
@@ -27,11 +27,16 @@ export class ActionExecutorService {
    * Execute resolved actions against Radarr/Sonarr.
    * In dry-run mode, every result is marked as 'skipped' with no API calls.
    * In live mode, each actionable item is executed sequentially.
+   *
+   * @param isAbandoned polled before each action. Executing a queue of deletes
+   * can outlive the evaluation's deadline, and once that passes the scheduler
+   * is free to start another run — so the caller gets a say in stopping.
    */
   async execute(
     results: EvaluationItemResult[],
     items: UnifiedMedia[],
     dryRun: boolean,
+    isAbandoned?: () => boolean,
   ): Promise<{
     results: EvaluationItemResult[];
     executionSummary?: ExecutionSummary;
@@ -78,7 +83,30 @@ export class ActionExecutorService {
     const counts: Record<Action, number> = { keep: 0, unmonitor: 0, delete: 0 };
     let failedCount = 0;
 
-    for (const result of results) {
+    for (const [index, result] of results.entries()) {
+      // The deadline can elapse mid-queue. Everything still pending belongs to
+      // a run that has already been written off, so stop here rather than
+      // deleting against a library another evaluation may now be acting on.
+      if (isAbandoned?.()) {
+        this.logger.error(
+          `Execution stopped after ${index} of ${results.length} results: the evaluation exceeded its deadline mid-run. ` +
+            `${counts.delete} deletes, ${counts.unmonitor} unmonitors already executed; the rest were skipped.`,
+        );
+
+        for (const pending of results.slice(index)) {
+          executed.push({ ...pending, execution_status: 'skipped' });
+        }
+
+        return {
+          results: executed,
+          executionSummary: {
+            actions_executed: counts,
+            actions_failed: failedCount,
+            aborted_reason: 'evaluation_abandoned',
+          },
+        };
+      }
+
       if (!result.resolved_action || result.resolved_action === 'keep') {
         executed.push({ ...result, execution_status: 'skipped' });
         continue;

--- a/src/execution/action-executor.service.ts
+++ b/src/execution/action-executor.service.ts
@@ -13,6 +13,15 @@ import {
 import { SonarrClient } from '../sonarr/sonarr.client';
 import type { ExecutionSummary } from './execution.types';
 
+interface ExecuteActionsOptions {
+  results: EvaluationItemResult[];
+  items: UnifiedMedia[];
+  dryRun: boolean;
+  isAbandoned?: () => boolean;
+}
+
+class ExecutionAbandonedError extends Error {}
+
 @Injectable()
 export class ActionExecutorService {
   private readonly logger = new Logger(ActionExecutorService.name);
@@ -28,16 +37,16 @@ export class ActionExecutorService {
    * In dry-run mode, every result is marked as 'skipped' with no API calls.
    * In live mode, each actionable item is executed sequentially.
    *
-   * @param isAbandoned polled before each action. Executing a queue of deletes
-   * can outlive the evaluation's deadline, and once that passes the scheduler
-   * is free to start another run — so the caller gets a say in stopping.
+   * The abandonment callback is polled before every API request. Executing a
+   * queue of deletes can outlive the evaluation's deadline, and once that
+   * passes the scheduler is free to start another run.
    */
-  async execute(
-    results: EvaluationItemResult[],
-    items: UnifiedMedia[],
-    dryRun: boolean,
-    isAbandoned?: () => boolean,
-  ): Promise<{
+  async execute({
+    results,
+    items,
+    dryRun,
+    isAbandoned,
+  }: ExecuteActionsOptions): Promise<{
     results: EvaluationItemResult[];
     executionSummary?: ExecutionSummary;
   }> {
@@ -124,10 +133,29 @@ export class ActionExecutorService {
       }
 
       try {
-        await this.executeAction(item, result.resolved_action);
+        await this.executeAction({
+          item,
+          action: result.resolved_action,
+          isAbandoned,
+        });
         executed.push({ ...result, execution_status: 'success' });
         counts[result.resolved_action]++;
       } catch (error) {
+        if (error instanceof ExecutionAbandonedError) {
+          executed.push({ ...result, execution_status: 'skipped' });
+          for (const pending of results.slice(index + 1)) {
+            executed.push({ ...pending, execution_status: 'skipped' });
+          }
+          return {
+            results: executed,
+            executionSummary: {
+              actions_executed: counts,
+              actions_failed: failedCount,
+              aborted_reason: 'evaluation_abandoned',
+            },
+          };
+        }
+
         if (this.isNotFound(error)) {
           this.logger.warn(
             `${result.resolved_action} "${result.title}": 404 — already removed`,
@@ -158,19 +186,24 @@ export class ActionExecutorService {
     };
   }
 
-  private async executeAction(
-    item: UnifiedMedia,
-    action: Action,
-  ): Promise<void> {
+  private async executeAction({
+    item,
+    action,
+    isAbandoned,
+  }: {
+    item: UnifiedMedia;
+    action: Action;
+    isAbandoned?: () => boolean;
+  }): Promise<void> {
     switch (action) {
       case 'delete':
         return item.type === 'movie'
           ? this.deleteMovie(item)
-          : this.deleteSeasonFiles(item);
+          : this.deleteSeasonFiles({ season: item, isAbandoned });
       case 'unmonitor':
         return item.type === 'movie'
-          ? this.unmonitorMovie(item)
-          : this.unmonitorSeason(item);
+          ? this.unmonitorMovie({ movie: item, isAbandoned })
+          : this.unmonitorSeason({ season: item, isAbandoned });
       case 'keep':
         return;
       default:
@@ -190,12 +223,19 @@ export class ActionExecutorService {
    * flipping `monitored` to false, and PUTting the full body back.
    * This avoids metadata corruption from partial request bodies.
    */
-  private async unmonitorMovie(movie: UnifiedMovie): Promise<void> {
+  private async unmonitorMovie({
+    movie,
+    isAbandoned,
+  }: {
+    movie: UnifiedMovie;
+    isAbandoned?: () => boolean;
+  }): Promise<void> {
     this.logger.log(
       `Unmonitoring movie "${movie.title}" (radarr_id: ${movie.radarr_id})`,
     );
     const fresh = await this.radarrClient.fetchMovie(movie.radarr_id);
     fresh.monitored = false;
+    this.throwIfAbandoned(isAbandoned);
     await this.radarrClient.updateMovie(movie.radarr_id, fresh);
   }
 
@@ -203,7 +243,13 @@ export class ActionExecutorService {
    * Delete all episode files for a specific season.
    * Fetches episode files lazily — only when deletion is actually needed.
    */
-  private async deleteSeasonFiles(season: UnifiedSeason): Promise<void> {
+  private async deleteSeasonFiles({
+    season,
+    isAbandoned,
+  }: {
+    season: UnifiedSeason;
+    isAbandoned?: () => boolean;
+  }): Promise<void> {
     const seasonNumber = season.sonarr.season.season_number;
     this.logger.log(
       `Deleting files for "${season.title}" S${String(seasonNumber).padStart(2, '0')} (series_id: ${season.sonarr_series_id})`,
@@ -225,6 +271,7 @@ export class ActionExecutorService {
     let alreadyRemovedCount = 0;
 
     for (const file of seasonFiles) {
+      this.throwIfAbandoned(isAbandoned);
       try {
         await this.sonarrClient.deleteEpisodeFile(file.id);
         deletedCount++;
@@ -253,7 +300,13 @@ export class ActionExecutorService {
    * flipping the target season's `monitored` to false, and PUTting
    * the full series body back.
    */
-  private async unmonitorSeason(season: UnifiedSeason): Promise<void> {
+  private async unmonitorSeason({
+    season,
+    isAbandoned,
+  }: {
+    season: UnifiedSeason;
+    isAbandoned?: () => boolean;
+  }): Promise<void> {
     const seasonNumber = season.sonarr.season.season_number;
     this.logger.log(
       `Unmonitoring "${season.title}" S${String(seasonNumber).padStart(2, '0')} (series_id: ${season.sonarr_series_id})`,
@@ -272,7 +325,12 @@ export class ActionExecutorService {
     }
 
     targetSeason.monitored = false;
+    this.throwIfAbandoned(isAbandoned);
     await this.sonarrClient.updateSeries(season.sonarr_series_id, freshSeries);
+  }
+
+  private throwIfAbandoned(isAbandoned?: () => boolean): void {
+    if (isAbandoned?.()) throw new ExecutionAbandonedError();
   }
 
   /** Check if an error is a 404 Not Found response from Axios. */

--- a/src/execution/action-executor.service.ts
+++ b/src/execution/action-executor.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { AxiosError } from 'axios';
 import type { Action } from '../config/config.schema';
+import { ConfigService } from '../config/config.service';
 import { RadarrClient } from '../radarr/radarr.client';
 import type { EvaluationItemResult } from '../rules/types';
 import {
@@ -19,6 +20,7 @@ export class ActionExecutorService {
   constructor(
     private readonly radarrClient: RadarrClient,
     private readonly sonarrClient: SonarrClient,
+    private readonly configService: ConfigService,
   ) {}
 
   /**
@@ -41,6 +43,32 @@ export class ActionExecutorService {
           execution_status: 'skipped' as const,
         })),
       };
+
+    const { max_deletes_per_run } = this.configService.getConfig().safety;
+    const deleteCount = results.filter(
+      r => r.resolved_action === 'delete',
+    ).length;
+
+    // A rule change or upstream data shift can unprotect a large share of the
+    // library at once. Refusing the whole run is recoverable; deleting it is not.
+    if (max_deletes_per_run !== null && deleteCount > max_deletes_per_run) {
+      this.logger.error(
+        `Aborting execution: ${deleteCount} deletes resolved, exceeding safety.max_deletes_per_run (${max_deletes_per_run}). ` +
+          'No actions were executed. Review the pending deletions, then either raise the limit or correct the rules.',
+      );
+
+      return {
+        results: results.map(r => ({
+          ...r,
+          execution_status: 'skipped' as const,
+        })),
+        executionSummary: {
+          actions_executed: { keep: 0, unmonitor: 0, delete: 0 },
+          actions_failed: 0,
+          aborted_reason: 'max_deletes_per_run_exceeded',
+        },
+      };
+    }
 
     const itemsByInternalId = new Map(
       items.map(item => [buildInternalId(item), item]),

--- a/src/execution/execution.types.ts
+++ b/src/execution/execution.types.ts
@@ -1,11 +1,20 @@
 import type { Action } from '../config/config.schema';
 
+/** Why a run stopped short of executing every resolved action. */
+export type AbortReason =
+  /** More deletes were resolved than `safety.max_deletes_per_run` allows. */
+  | 'max_deletes_per_run_exceeded'
+  /** The evaluation exceeded `safety.evaluation_timeout` partway through. */
+  | 'evaluation_abandoned';
+
 export interface ExecutionSummary {
   actions_executed: Record<Action, number>;
   actions_failed: number;
   /**
-   * Set when a safety limit stopped the run before any action was executed.
-   * Absent on normal runs.
+   * Set when a safety limit stopped the run short. Absent on normal runs.
+   * `max_deletes_per_run_exceeded` stops before anything is executed;
+   * `evaluation_abandoned` can stop partway, so `actions_executed` may be
+   * non-zero alongside it.
    */
-  aborted_reason?: 'max_deletes_per_run_exceeded';
+  aborted_reason?: AbortReason;
 }

--- a/src/execution/execution.types.ts
+++ b/src/execution/execution.types.ts
@@ -3,4 +3,9 @@ import type { Action } from '../config/config.schema';
 export interface ExecutionSummary {
   actions_executed: Record<Action, number>;
   actions_failed: number;
+  /**
+   * Set when a safety limit stopped the run before any action was executed.
+   * Absent on normal runs.
+   */
+  aborted_reason?: 'max_deletes_per_run_exceeded';
 }

--- a/src/jellyfin/jellyfin.client.test.ts
+++ b/src/jellyfin/jellyfin.client.test.ts
@@ -291,22 +291,49 @@ describe('JellyfinClient', () => {
       expect(calls).toBe(2);
     });
 
-    test('stops when TotalRecordCount is missing', async () => {
+    test('stops on a short page even when TotalRecordCount is larger', async () => {
       const { client, http } = await setup();
       let calls = 0;
 
+      // Fewer items than the page size means the result set is exhausted;
+      // asking for the next page would only skip records.
       http.get = () => {
         calls++;
         return of(
           axiosResponse({
-            Items: [makeJellyfinItem({ Id: `item-${calls}` })],
+            Items: Array.from({ length: 40 }, (_, i) =>
+              makeJellyfinItem({ Id: `item-${i}` }),
+            ),
+            TotalRecordCount: 5000,
+          }),
+        ) as any;
+      };
+
+      const result = await client.fetchPlayedMovies('user-1');
+
+      expect(result).toHaveLength(40);
+      expect(calls).toBe(1);
+    });
+
+    test('stops when TotalRecordCount is missing', async () => {
+      const { client, http } = await setup();
+      let calls = 0;
+
+      // A full page, so termination can only come from the missing count.
+      http.get = () => {
+        calls++;
+        return of(
+          axiosResponse({
+            Items: Array.from({ length: 100 }, (_, i) =>
+              makeJellyfinItem({ Id: `item-${i}` }),
+            ),
           }),
         ) as any;
       };
 
       const result = await client.fetchSeriesItems('user-1');
 
-      expect(result).toHaveLength(1);
+      expect(result).toHaveLength(100);
       expect(calls).toBe(1);
     });
 
@@ -314,7 +341,7 @@ describe('JellyfinClient', () => {
       const { client, http } = await setup();
       http.get = () => of(axiosResponse({ TotalRecordCount: 10 })) as any;
 
-      expect(client.fetchSeriesItems('user-1')).rejects.toThrow(
+      await expect(client.fetchSeriesItems('user-1')).rejects.toThrow(
         /malformed page/,
       );
     });

--- a/src/jellyfin/jellyfin.client.test.ts
+++ b/src/jellyfin/jellyfin.client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, mock, test } from 'bun:test';
 import { HttpModule, HttpService } from '@nestjs/axios';
 import { Test } from '@nestjs/testing';
 import { of } from 'rxjs';
@@ -291,28 +291,50 @@ describe('JellyfinClient', () => {
       expect(calls).toBe(2);
     });
 
-    test('stops on a short page even when TotalRecordCount is larger', async () => {
+    test('reads the whole set from a server that caps its page size', async () => {
       const { client, http } = await setup();
       let calls = 0;
 
-      // Fewer items than the page size means the result set is exhausted;
-      // asking for the next page would only skip records.
-      http.get = () => {
+      // Serves a 100-item library 40 at a time despite Limit=100. Advancing by
+      // the requested limit instead of the received count would read 40 items
+      // and silently report them as the entire library.
+      const corpus = Array.from({ length: 100 }, (_, i) =>
+        makeJellyfinItem({ Id: `item-${i}` }),
+      );
+
+      http.get = (_url: string, config: any) => {
         calls++;
+        const start = config.params.StartIndex;
         return of(
           axiosResponse({
-            Items: Array.from({ length: 40 }, (_, i) =>
-              makeJellyfinItem({ Id: `item-${i}` }),
-            ),
-            TotalRecordCount: 5000,
+            Items: corpus.slice(start, start + 40),
+            TotalRecordCount: corpus.length,
           }),
         ) as any;
       };
 
       const result = await client.fetchPlayedMovies('user-1');
 
-      expect(result).toHaveLength(40);
-      expect(calls).toBe(1);
+      expect(result).toHaveLength(100);
+      expect(result.map(i => i.Id)).toEqual(corpus.map(i => i.Id));
+      expect(calls).toBe(3);
+    });
+
+    test('warns when a short page ends a set with no TotalRecordCount', async () => {
+      const { client, http } = await setup();
+      const warn = mock();
+      (client as any).logger = { debug: mock(), warn };
+
+      http.get = () =>
+        of(
+          axiosResponse({ Items: [makeJellyfinItem({ Id: 'item-1' })] }),
+        ) as any;
+
+      const result = await client.fetchSeriesItems('user-1');
+
+      expect(result).toHaveLength(1);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toMatch(/omitted TotalRecordCount/);
     });
 
     test('throws when TotalRecordCount is missing after a full page', async () => {

--- a/src/jellyfin/jellyfin.client.test.ts
+++ b/src/jellyfin/jellyfin.client.test.ts
@@ -267,4 +267,78 @@ describe('JellyfinClient', () => {
       expect(result).toEqual([]);
     });
   });
+  describe('pagination termination', () => {
+    test('stops on an empty page even when TotalRecordCount is larger', async () => {
+      const { client, http } = await setup();
+      let calls = 0;
+
+      // The shape that previously spun forever: a short first page, then empty
+      // pages, with the server still claiming more records exist.
+      http.get = () => {
+        calls++;
+        const Items =
+          calls === 1
+            ? Array.from({ length: 100 }, (_, i) =>
+                makeJellyfinItem({ Id: `item-${i}` }),
+              )
+            : [];
+        return of(axiosResponse({ Items, TotalRecordCount: 5000 })) as any;
+      };
+
+      const result = await client.fetchPlayedMovies('user-1');
+
+      expect(result).toHaveLength(100);
+      expect(calls).toBe(2);
+    });
+
+    test('stops when TotalRecordCount is missing', async () => {
+      const { client, http } = await setup();
+      let calls = 0;
+
+      http.get = () => {
+        calls++;
+        return of(
+          axiosResponse({
+            Items: [makeJellyfinItem({ Id: `item-${calls}` })],
+          }),
+        ) as any;
+      };
+
+      const result = await client.fetchSeriesItems('user-1');
+
+      expect(result).toHaveLength(1);
+      expect(calls).toBe(1);
+    });
+
+    test('throws when a page is missing its Items array', async () => {
+      const { client, http } = await setup();
+      http.get = () => of(axiosResponse({ TotalRecordCount: 10 })) as any;
+
+      expect(client.fetchSeriesItems('user-1')).rejects.toThrow(
+        /malformed page/,
+      );
+    });
+
+    test('paginates until TotalRecordCount is reached', async () => {
+      const { client, http } = await setup();
+      let calls = 0;
+
+      http.get = () => {
+        calls++;
+        return of(
+          axiosResponse({
+            Items: Array.from({ length: 100 }, (_, i) =>
+              makeJellyfinItem({ Id: `page-${calls}-item-${i}` }),
+            ),
+            TotalRecordCount: 250,
+          }),
+        ) as any;
+      };
+
+      const result = await client.fetchSeriesItems('user-1');
+
+      expect(result).toHaveLength(300);
+      expect(calls).toBe(3);
+    });
+  });
 });

--- a/src/jellyfin/jellyfin.client.test.ts
+++ b/src/jellyfin/jellyfin.client.test.ts
@@ -315,26 +315,61 @@ describe('JellyfinClient', () => {
       expect(calls).toBe(1);
     });
 
-    test('stops when TotalRecordCount is missing', async () => {
+    test('throws when TotalRecordCount is missing after a full page', async () => {
       const { client, http } = await setup();
-      let calls = 0;
 
-      // A full page, so termination can only come from the missing count.
-      http.get = () => {
-        calls++;
-        return of(
+      // A full page means more items may exist; without a total there is no
+      // way to know, and a short library silently unprotects everything.
+      http.get = () =>
+        of(
           axiosResponse({
             Items: Array.from({ length: 100 }, (_, i) =>
               makeJellyfinItem({ Id: `item-${i}` }),
             ),
           }),
         ) as any;
+
+      await expect(client.fetchSeriesItems('user-1')).rejects.toThrow(
+        /omitted TotalRecordCount/,
+      );
+    });
+
+    test('accepts a short page with no TotalRecordCount', async () => {
+      const { client, http } = await setup();
+      let calls = 0;
+
+      // Short page — the result set is provably exhausted, so the missing
+      // total is not load-bearing.
+      http.get = () => {
+        calls++;
+        return of(
+          axiosResponse({ Items: [makeJellyfinItem({ Id: 'item-1' })] }),
+        ) as any;
       };
 
       const result = await client.fetchSeriesItems('user-1');
 
-      expect(result).toHaveLength(100);
+      expect(result).toHaveLength(1);
       expect(calls).toBe(1);
+    });
+
+    test('throws rather than returning a truncated set at the page ceiling', async () => {
+      const { client, http } = await setup();
+
+      // A server whose TotalRecordCount never becomes reachable.
+      http.get = () =>
+        of(
+          axiosResponse({
+            Items: Array.from({ length: 100 }, (_, i) =>
+              makeJellyfinItem({ Id: `item-${i}` }),
+            ),
+            TotalRecordCount: Number.MAX_SAFE_INTEGER,
+          }),
+        ) as any;
+
+      await expect(client.fetchPlayedMovies('user-1')).rejects.toThrow(
+        /exceeded 1000 pages/,
+      );
     });
 
     test('throws when a page is missing its Items array', async () => {

--- a/src/jellyfin/jellyfin.client.ts
+++ b/src/jellyfin/jellyfin.client.ts
@@ -130,25 +130,35 @@ export class JellyfinClient {
 
       allItems.push(...data.Items);
 
-      // A page smaller than the limit means the result set is exhausted —
-      // an empty page makes no progress at all, and a short one would only
-      // skip records if we advanced past it. Neither depends on
-      // TotalRecordCount, which is what a misreporting server gets wrong.
-      if (data.Items.length < pageSize) return allItems;
+      // An empty page makes no progress, so nothing more is coming regardless
+      // of what the server claims the total to be.
+      if (data.Items.length === 0) return allItems;
 
-      // A full page with no total means more items may exist and there is no
-      // way to know. Returning what we have would look like a complete library
-      // to every caller, and an item missing from watch data is an item nothing
-      // is protecting — so refuse rather than under-report.
+      // Advance by what arrived rather than by what was asked for. A server
+      // that caps its page size below our limit still paginates correctly
+      // this way; advancing by the limit would skip every record in the gap.
+      startIndex += data.Items.length;
+
       const total = data.TotalRecordCount;
-      if (!Number.isFinite(total)) {
-        throw new Error(
-          `Jellyfin omitted TotalRecordCount for /Users/${userId}/Items after a full page — cannot determine whether ${allItems.length} items is the complete set`,
-        );
+      if (Number.isFinite(total)) {
+        if (allItems.length >= total) return allItems;
+        continue;
       }
 
-      if (allItems.length >= total) return allItems;
-      startIndex += pageSize;
+      // With no total there is nothing to check the result against. A short
+      // page is the end of the set. A full one means more may exist with no
+      // way to tell, and an item missing from watch data is an item nothing is
+      // protecting — so refuse rather than silently under-report.
+      if (data.Items.length < pageSize) {
+        this.logger.warn(
+          `Jellyfin omitted TotalRecordCount for /Users/${userId}/Items — treating the short page that followed as the end of the set at ${allItems.length} items`,
+        );
+        return allItems;
+      }
+
+      throw new Error(
+        `Jellyfin omitted TotalRecordCount for /Users/${userId}/Items after a full page — cannot determine whether ${allItems.length} items is the complete set`,
+      );
     }
 
     throw new Error(

--- a/src/jellyfin/jellyfin.client.ts
+++ b/src/jellyfin/jellyfin.client.ts
@@ -7,6 +7,13 @@ import type {
   JellyfinUser,
 } from './jellyfin.types';
 
+/**
+ * Hard ceiling on pagination requests for a single query. At the 100-item page
+ * size this covers libraries far larger than Jellyfin is used for, and stops a
+ * server that reports an inconsistent TotalRecordCount from looping forever.
+ */
+const MAX_PAGES = 1000;
+
 @Injectable()
 export class JellyfinClient {
   private readonly logger = new Logger(JellyfinClient.name);
@@ -102,7 +109,9 @@ export class JellyfinClient {
     const allItems: JellyfinItem[] = [];
     let startIndex = 0;
 
-    while (true) {
+    // Bounded by pages rather than `while (true)`: termination must not depend
+    // on the server reporting a consistent TotalRecordCount.
+    for (let page = 0; page < MAX_PAGES; page++) {
       const { data } = await firstValueFrom(
         this.http.get<JellyfinItemsResponse>(`/Users/${userId}/Items`, {
           params: {
@@ -113,12 +122,33 @@ export class JellyfinClient {
         }),
       );
 
+      if (!Array.isArray(data?.Items)) {
+        throw new Error(
+          `Jellyfin returned a malformed page for /Users/${userId}/Items (StartIndex ${startIndex}): missing Items array`,
+        );
+      }
+
       allItems.push(...data.Items);
 
-      if (allItems.length >= data.TotalRecordCount) break;
+      // An empty page makes no progress — treat it as the end of the result
+      // set regardless of what TotalRecordCount claims.
+      if (data.Items.length === 0) return allItems;
+
+      const total = data.TotalRecordCount;
+      if (!Number.isFinite(total)) {
+        this.logger.warn(
+          `Jellyfin omitted TotalRecordCount for /Users/${userId}/Items — stopping after ${allItems.length} items`,
+        );
+        return allItems;
+      }
+
+      if (allItems.length >= total) return allItems;
       startIndex += pageSize;
     }
 
+    this.logger.error(
+      `Jellyfin pagination for /Users/${userId}/Items exceeded ${MAX_PAGES} pages — returning ${allItems.length} items collected so far`,
+    );
     return allItems;
   }
 }

--- a/src/jellyfin/jellyfin.client.ts
+++ b/src/jellyfin/jellyfin.client.ts
@@ -130,9 +130,11 @@ export class JellyfinClient {
 
       allItems.push(...data.Items);
 
-      // An empty page makes no progress — treat it as the end of the result
-      // set regardless of what TotalRecordCount claims.
-      if (data.Items.length === 0) return allItems;
+      // A page smaller than the limit means the result set is exhausted —
+      // an empty page makes no progress at all, and a short one would only
+      // skip records if we advanced past it. Neither depends on
+      // TotalRecordCount, which is what a misreporting server gets wrong.
+      if (data.Items.length < pageSize) return allItems;
 
       const total = data.TotalRecordCount;
       if (!Number.isFinite(total)) {

--- a/src/jellyfin/jellyfin.client.ts
+++ b/src/jellyfin/jellyfin.client.ts
@@ -136,21 +136,23 @@ export class JellyfinClient {
       // TotalRecordCount, which is what a misreporting server gets wrong.
       if (data.Items.length < pageSize) return allItems;
 
+      // A full page with no total means more items may exist and there is no
+      // way to know. Returning what we have would look like a complete library
+      // to every caller, and an item missing from watch data is an item nothing
+      // is protecting — so refuse rather than under-report.
       const total = data.TotalRecordCount;
       if (!Number.isFinite(total)) {
-        this.logger.warn(
-          `Jellyfin omitted TotalRecordCount for /Users/${userId}/Items — stopping after ${allItems.length} items`,
+        throw new Error(
+          `Jellyfin omitted TotalRecordCount for /Users/${userId}/Items after a full page — cannot determine whether ${allItems.length} items is the complete set`,
         );
-        return allItems;
       }
 
       if (allItems.length >= total) return allItems;
       startIndex += pageSize;
     }
 
-    this.logger.error(
-      `Jellyfin pagination for /Users/${userId}/Items exceeded ${MAX_PAGES} pages — returning ${allItems.length} items collected so far`,
+    throw new Error(
+      `Jellyfin pagination for /Users/${userId}/Items exceeded ${MAX_PAGES} pages — refusing to return ${allItems.length} items as a complete set`,
     );
-    return allItems;
   }
 }

--- a/src/media/media.service.test.ts
+++ b/src/media/media.service.test.ts
@@ -171,6 +171,61 @@ describe('MediaService', () => {
     );
   });
 
+  test('fails when Jellyfin fields are configured without Jellyfin', async () => {
+    radarrService.fetchMovies = mock(() => Promise.resolve([]));
+    const serviceWithoutJellyfin = new MediaService(
+      sonarrService as any,
+      radarrService as any,
+      null,
+      jellyseerrService as any,
+    );
+    const rules: RuleConfig[] = [
+      makeRule({
+        conditions: {
+          operator: 'AND',
+          children: [
+            {
+              field: 'jellyfin.watched_by_all',
+              operator: 'equals',
+              value: true,
+            },
+          ],
+        },
+      }),
+    ];
+
+    await expect(serviceWithoutJellyfin.hydrate(rules)).rejects.toThrow(
+      'Jellyfin service is required by configured rules',
+    );
+  });
+
+  test('fails when Jellyseerr fields are configured without Jellyseerr', async () => {
+    const serviceWithoutJellyseerr = new MediaService(
+      sonarrService as any,
+      radarrService as any,
+      jellyfinService as any,
+      null,
+    );
+    const rules: RuleConfig[] = [
+      makeRule({
+        conditions: {
+          operator: 'AND',
+          children: [
+            {
+              field: 'jellyseerr.request_status',
+              operator: 'equals',
+              value: 'approved',
+            },
+          ],
+        },
+      }),
+    ];
+
+    await expect(serviceWithoutJellyseerr.hydrate(rules)).rejects.toThrow(
+      'Jellyseerr service is required by configured rules',
+    );
+  });
+
   test('propagates a Radarr base-data fetch failure', async () => {
     radarrService.fetchMovies = mock(() =>
       Promise.reject(new Error('Connection refused')),

--- a/src/media/media.service.test.ts
+++ b/src/media/media.service.test.ts
@@ -148,26 +148,45 @@ describe('MediaService', () => {
     expect(radarrService.fetchMovies).not.toHaveBeenCalled();
   });
 
-  test('handles null services gracefully', async () => {
+  test('fails when a required base service is unavailable', async () => {
     const serviceWithNulls = new MediaService(null, null, null, null);
     const rules: RuleConfig[] = [makeRule()];
 
-    const result = await serviceWithNulls.hydrate(rules);
-
-    expect(result).toEqual([]);
+    await expect(serviceWithNulls.hydrate(rules)).rejects.toThrow(
+      'Radarr service is required by configured rules',
+    );
   });
 
-  test('handles service fetch failure gracefully', async () => {
+  test('fails when Sonarr rules are configured without Sonarr', async () => {
+    const serviceWithoutSonarr = new MediaService(
+      null,
+      radarrService as any,
+      null,
+      null,
+    );
+    const rules: RuleConfig[] = [makeRule({ target: 'sonarr' })];
+
+    await expect(serviceWithoutSonarr.hydrate(rules)).rejects.toThrow(
+      'Sonarr service is required by configured rules',
+    );
+  });
+
+  test('propagates a Radarr base-data fetch failure', async () => {
     radarrService.fetchMovies = mock(() =>
       Promise.reject(new Error('Connection refused')),
     );
 
     const rules: RuleConfig[] = [makeRule()];
-    const result = await service.hydrate(rules);
+    await expect(service.hydrate(rules)).rejects.toThrow('Connection refused');
+  });
 
-    // Should return empty instead of throwing
-    const movies = result.filter(r => r.type === 'movie');
-    expect(movies).toHaveLength(0);
+  test('propagates a Sonarr base-data fetch failure', async () => {
+    sonarrService.fetchSeasons = mock(() =>
+      Promise.reject(new Error('Sonarr unreachable')),
+    );
+
+    const rules: RuleConfig[] = [makeRule({ target: 'sonarr' })];
+    await expect(service.hydrate(rules)).rejects.toThrow('Sonarr unreachable');
   });
 
   test('propagates a Jellyfin movie fetch failure instead of degrading', async () => {

--- a/src/media/media.service.test.ts
+++ b/src/media/media.service.test.ts
@@ -170,9 +170,12 @@ describe('MediaService', () => {
     expect(movies).toHaveLength(0);
   });
 
-  test('handles Jellyfin failure gracefully while still returning base data', async () => {
+  test('propagates a Jellyfin movie fetch failure instead of degrading', async () => {
+    // Swallowing this would leave every movie with jellyfin: null, which is
+    // indistinguishable from "nobody watched it" — silently dropping the keep
+    // rules that protect the library.
     jellyfinService.fetchMovieWatchData = mock(() =>
-      Promise.reject(new Error('Jellyfin offline')),
+      Promise.reject(new Error('Jellyfin unreachable')),
     );
 
     const rules: RuleConfig[] = [
@@ -190,11 +193,34 @@ describe('MediaService', () => {
       }),
     ];
 
-    const result = await service.hydrate(rules);
+    await expect(service.hydrate(rules)).rejects.toThrow(
+      'Jellyfin unreachable',
+    );
+  });
 
-    // Movies should still be present, just without Jellyfin enrichment
-    expect(result).toHaveLength(1);
-    expect(result[0].jellyfin).toBeNull();
+  test('propagates a Jellyseerr fetch failure instead of degrading', async () => {
+    jellyseerrService.fetchRequestData = mock(() =>
+      Promise.reject(new Error('Jellyseerr unreachable')),
+    );
+
+    const rules: RuleConfig[] = [
+      makeRule({
+        conditions: {
+          operator: 'AND',
+          children: [
+            {
+              field: 'jellyseerr.request_status',
+              operator: 'equals',
+              value: 'approved',
+            },
+          ],
+        },
+      }),
+    ];
+
+    await expect(service.hydrate(rules)).rejects.toThrow(
+      'Jellyseerr unreachable',
+    );
   });
 
   test('fetches both movies and seasons when both targets present', async () => {

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -31,6 +31,11 @@ export class MediaService {
    * Hydrate unified media models based on the given rules.
    * Only fetches from services that are actually referenced
    * in rule conditions (lazy fetching).
+   *
+   * @throws if an enrichment service that some rule depends on cannot be
+   * reached. Absent enrichment data is indistinguishable from "this item has
+   * no watch history", which silently drops the `keep` rules guarding the
+   * library, so a failed fetch must fail the run rather than degrade it.
    */
   async hydrate(rules: RuleConfig[]): Promise<UnifiedMedia[]> {
     const neededServices = this.analyzeNeededServices(rules);
@@ -51,13 +56,13 @@ export class MediaService {
     const [jellyfinMovieData, jellyfinSeasonData, jellyseerrData] =
       await Promise.all([
         neededServices.has('jellyfin') && movies.length > 0
-          ? this.fetchJellyfinMoviesSafe()
+          ? this.fetchJellyfinMovieData()
           : Promise.resolve(null),
         neededServices.has('jellyfin') && seasons.length > 0
-          ? this.fetchJellyfinSeasonsSafe(seasons)
+          ? this.fetchJellyfinSeasonData(seasons)
           : Promise.resolve(null),
         neededServices.has('jellyseerr')
-          ? this.fetchJellyseerrSafe()
+          ? this.fetchJellyseerrData()
           : Promise.resolve(null),
       ]);
 
@@ -135,7 +140,7 @@ export class MediaService {
     }
   }
 
-  private async fetchJellyfinMoviesSafe(): Promise<Map<
+  private async fetchJellyfinMovieData(): Promise<Map<
     number,
     JellyfinData
   > | null> {
@@ -145,15 +150,10 @@ export class MediaService {
       );
       return null;
     }
-    try {
-      return await this.jellyfinService.fetchMovieWatchData();
-    } catch (error) {
-      this.logger.warn(`Jellyfin movie fetch failed, skipping: ${error}`);
-      return null;
-    }
+    return this.jellyfinService.fetchMovieWatchData();
   }
 
-  private async fetchJellyfinSeasonsSafe(
+  private async fetchJellyfinSeasonData(
     seasons: Array<{
       tvdb_id: number;
       sonarr: { season: { season_number: number } };
@@ -165,30 +165,20 @@ export class MediaService {
       );
       return null;
     }
-    try {
-      const identifiers: SeasonIdentifier[] = seasons.map(s => ({
-        tvdbId: s.tvdb_id,
-        seasonNumber: s.sonarr.season.season_number,
-      }));
-      return await this.jellyfinService.fetchSeasonWatchData(identifiers);
-    } catch (error) {
-      this.logger.warn(`Jellyfin season fetch failed, skipping: ${error}`);
-      return null;
-    }
+    const identifiers: SeasonIdentifier[] = seasons.map(s => ({
+      tvdbId: s.tvdb_id,
+      seasonNumber: s.sonarr.season.season_number,
+    }));
+    return this.jellyfinService.fetchSeasonWatchData(identifiers);
   }
 
-  private async fetchJellyseerrSafe(): Promise<JellyseerrIndexes | null> {
+  private async fetchJellyseerrData(): Promise<JellyseerrIndexes | null> {
     if (!this.jellyseerrService) {
       this.logger.warn(
         'Jellyseerr service not available, skipping request data',
       );
       return null;
     }
-    try {
-      return await this.jellyseerrService.fetchRequestData();
-    } catch (error) {
-      this.logger.warn(`Jellyseerr fetch failed, skipping: ${error}`);
-      return null;
-    }
+    return this.jellyseerrService.fetchRequestData();
   }
 }

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -32,10 +32,9 @@ export class MediaService {
    * Only fetches from services that are actually referenced
    * in rule conditions (lazy fetching).
    *
-   * @throws if an enrichment service that some rule depends on cannot be
-   * reached. Absent enrichment data is indistinguishable from "this item has
-   * no watch history", which silently drops the `keep` rules guarding the
-   * library, so a failed fetch must fail the run rather than degrade it.
+   * @throws if a required base or enrichment service is unavailable or cannot
+   * be reached. Missing data can silently drop `keep` rules guarding the
+   * library, so hydration must fail rather than degrade to an empty result.
    */
   async hydrate(rules: RuleConfig[]): Promise<UnifiedMedia[]> {
     const neededServices = this.analyzeNeededServices(rules);
@@ -48,8 +47,8 @@ export class MediaService {
 
     // Fetch base data from Sonarr/Radarr in parallel
     const [movies, seasons] = await Promise.all([
-      hasRadarrRules ? this.fetchMoviesSafe() : Promise.resolve([]),
-      hasSonarrRules ? this.fetchSeasonsSafe() : Promise.resolve([]),
+      hasRadarrRules ? this.fetchMovies() : Promise.resolve([]),
+      hasSonarrRules ? this.fetchSeasons() : Promise.resolve([]),
     ]);
 
     // Fetch enrichment data in parallel (only if needed)
@@ -114,30 +113,18 @@ export class MediaService {
     }
   }
 
-  private async fetchMoviesSafe() {
+  private async fetchMovies() {
     if (!this.radarrService) {
-      this.logger.warn('Radarr service not available, skipping movie fetch');
-      return [];
+      throw new Error('Radarr service is required by configured rules');
     }
-    try {
-      return await this.radarrService.fetchMovies();
-    } catch (error) {
-      this.logger.warn(`Radarr fetch failed, skipping: ${error}`);
-      return [];
-    }
+    return this.radarrService.fetchMovies();
   }
 
-  private async fetchSeasonsSafe() {
+  private async fetchSeasons() {
     if (!this.sonarrService) {
-      this.logger.warn('Sonarr service not available, skipping season fetch');
-      return [];
+      throw new Error('Sonarr service is required by configured rules');
     }
-    try {
-      return await this.sonarrService.fetchSeasons();
-    } catch (error) {
-      this.logger.warn(`Sonarr fetch failed, skipping: ${error}`);
-      return [];
-    }
+    return this.sonarrService.fetchSeasons();
   }
 
   private async fetchJellyfinMovieData(): Promise<Map<

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -41,6 +41,13 @@ export class MediaService {
     const hasRadarrRules = rules.some(r => r.target === 'radarr');
     const hasSonarrRules = rules.some(r => r.target === 'sonarr');
 
+    if (neededServices.has('jellyfin') && !this.jellyfinService) {
+      throw new Error('Jellyfin service is required by configured rules');
+    }
+    if (neededServices.has('jellyseerr') && !this.jellyseerrService) {
+      throw new Error('Jellyseerr service is required by configured rules');
+    }
+
     this.logger.log(
       `Hydrating media: services needed = [${[...neededServices].join(', ')}]`,
     );
@@ -127,15 +134,9 @@ export class MediaService {
     return this.sonarrService.fetchSeasons();
   }
 
-  private async fetchJellyfinMovieData(): Promise<Map<
-    number,
-    JellyfinData
-  > | null> {
+  private async fetchJellyfinMovieData(): Promise<Map<number, JellyfinData>> {
     if (!this.jellyfinService) {
-      this.logger.warn(
-        'Jellyfin service not available, skipping movie watch data',
-      );
-      return null;
+      throw new Error('Jellyfin service is required by configured rules');
     }
     return this.jellyfinService.fetchMovieWatchData();
   }
@@ -145,12 +146,9 @@ export class MediaService {
       tvdb_id: number;
       sonarr: { season: { season_number: number } };
     }>,
-  ): Promise<Map<string, JellyfinData> | null> {
+  ): Promise<Map<string, JellyfinData>> {
     if (!this.jellyfinService) {
-      this.logger.warn(
-        'Jellyfin service not available, skipping season watch data',
-      );
-      return null;
+      throw new Error('Jellyfin service is required by configured rules');
     }
     const identifiers: SeasonIdentifier[] = seasons.map(s => ({
       tvdbId: s.tvdb_id,
@@ -159,12 +157,9 @@ export class MediaService {
     return this.jellyfinService.fetchSeasonWatchData(identifiers);
   }
 
-  private async fetchJellyseerrData(): Promise<JellyseerrIndexes | null> {
+  private async fetchJellyseerrData(): Promise<JellyseerrIndexes> {
     if (!this.jellyseerrService) {
-      this.logger.warn(
-        'Jellyseerr service not available, skipping request data',
-      );
-      return null;
+      throw new Error('Jellyseerr service is required by configured rules');
     }
     return this.jellyseerrService.fetchRequestData();
   }

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -3,6 +3,7 @@ import type {
   ConditionGroup,
   RuleConfig,
 } from '../config/config.schema';
+import type { AbortReason } from '../execution/execution.types';
 export type { Action, ConditionGroup, RuleConfig };
 
 export type ExecutionStatus = 'success' | 'failed' | 'skipped' | 'not_found';
@@ -35,6 +36,11 @@ export interface EvaluationSummary {
   /** Present only when dry_run is false. */
   actions_executed?: Record<Action, number>;
   actions_failed?: number;
+  /**
+   * Present only when a safety limit stopped execution short. Its absence on a
+   * completed run means every resolved action was attempted.
+   */
+  aborted_reason?: AbortReason;
 }
 
 export interface RuleMatch {

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -172,6 +172,7 @@ export function makeConfig(
     schedule: '0 3 * * *',
     performance: { concurrency: 10 },
     audit: { retention_days: 90 },
+    safety: { evaluation_timeout: '1h', max_deletes_per_run: 50 },
     rules: [makeRule()],
     ...overrides,
   };


### PR DESCRIPTION
## Why

A production instance wedged on **2026-07-23 08:00 UTC** and skipped **26 consecutive scheduled evaluations**, doing nothing for 26 days until it was captured for forensics.

`MediaService.hydrate` never settled, so `executeEvaluation` never reached its `finally` block, the running flag stayed set, and every later cron declined to start. The outage produced no error-level logs. Audit history shows earlier multi-day gaps that recovered only after container restarts.

Separately, execution had no deletion ceiling. On the affected instance, one retention-rule change resolves **362 deletes / 8.08 TiB** in a single run.

## What changed

### Bound evaluation runtime

`safety.evaluation_timeout` adds a wall-clock budget per run (default `1h`, maximum ~24.8 days). When it expires, the run fails at error level and releases the scheduler so the next evaluation can proceed.

The underlying promise cannot be cancelled. Abandoned runs therefore check their status at every pipeline boundary and throughout action execution. If work later resumes, it stops before further snapshots, audit entries, actions, or completion writes. Multi-request actions also check between remote mutations. Any partial execution is recorded with `aborted_reason: evaluation_abandoned`.

### Cap deletes per run

`safety.max_deletes_per_run` refuses a run that resolves more deletes than the configured limit (default `50`). No actions execute, the run summary records `max_deletes_per_run_exceeded`, and an error explains how to review or deliberately raise the limit. `null` disables the cap.

### Fail closed on incomplete hydration

Rules form an allowlist: missing enrichment can make a protective `keep` rule stop matching while a catch-all `delete` rule remains armed. Hydration now fails the entire run when a required Radarr, Sonarr, Jellyfin, or Jellyseerr service is missing or unreachable. It no longer converts service failures into empty or null datasets, and it fails before snapshotting incomplete library state.

### Make Jellyfin pagination complete and bounded

Jellyfin pagination now:

- validates that every response contains an `Items` array;
- advances by items actually received, supporting servers that cap page size below the requested limit;
- treats `TotalRecordCount` as a consistency signal rather than the only loop exit;
- accepts a missing total only after a short terminal page, with a warning;
- rejects ambiguous full pages without a total instead of returning a possibly partial library;
- stops on an empty page; and
- fails after 1,000 pages rather than looping forever.

This pagination bug was latent, not the captured July wedge: the captured process had flat CPU/network and no Jellyfin socket, while an infinite pagination loop would keep making requests.

## Root cause of the captured hang

Not pinned. Axios 1.13.5 under Bun 1.3.10 honored the configured 30-second timeout against both a never-responding server and a mid-body socket failure. At capture, the process had no live Jellyfin socket. Diagnosing the specific lost wakeup requires inspecting a recurrence.

The runtime deadline and fail-closed data checks are independent of that diagnosis.

## Configuration

```yaml
safety:
  evaluation_timeout: 1h
  max_deletes_per_run: 50
```

Both keys are optional and default as shown. Existing 0.2.1 images strip unknown `safety` keys, so deploy the new image before relying on these limits.

## Testing

- `bun run typecheck`
- `bun run lint`
- `bun run test` — **481 pass, 0 fail**

Coverage includes never-settling hydration, scheduler recovery, abandonment at each pipeline/action boundary, partial-execution reporting, deletion-cap boundaries, missing and unreachable required services, malformed/empty/partial Jellyfin pages, server-capped page sizes, missing totals, and page-ceiling failure.
